### PR TITLE
Big integer and partial validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "justus",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "justus",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@plugjs/build": "^0.5.7",
-        "@plugjs/tsd": "^0.5.7",
+        "@plugjs/build": "^0.5.9",
+        "@plugjs/tsd": "^0.5.9",
         "@types/chai": "^4.3.9",
         "chai": "^4.3.10",
         "typescript": "^5.2.2"
@@ -638,21 +638,21 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
-      "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
+      "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
-      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
+      "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
+        "@humanwhocodes/object-schema": "^2.0.1",
         "debug": "^4.1.1",
         "minimatch": "^3.0.5"
       },
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
+      "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true
     },
     "node_modules/@jest/schemas": {
@@ -727,56 +727,56 @@
       }
     },
     "node_modules/@plugjs/build": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@plugjs/build/-/build-0.5.7.tgz",
-      "integrity": "sha512-R35dkbRtdAY5BEbbXMbeNNp3TjBwqfsplO7sVMiAa/vcNAZBDi3OUdjwdb0ib1Ptltp2bry+PH6RHtfxIHSv2g==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@plugjs/build/-/build-0.5.9.tgz",
+      "integrity": "sha512-yCKNxIDHrQK9TJtH/5IdqOmjQhamFregnbmTX1Ysp1zaXTyevUV6lyxJhC5NmpE1VnNeRyAbcY4sDSdFp26zPg==",
       "dev": true,
       "dependencies": {
-        "@plugjs/cov8": "^0.5.7",
-        "@plugjs/eslint": "^0.5.7",
+        "@plugjs/cov8": "^0.5.9",
+        "@plugjs/eslint": "^0.5.9",
         "@plugjs/eslint-plugin": "^0.1.13",
-        "@plugjs/expect5": "^0.5.7",
-        "@plugjs/plug": "^0.5.7",
-        "@plugjs/typescript": "^0.5.7"
+        "@plugjs/expect5": "^0.5.9",
+        "@plugjs/plug": "^0.5.9",
+        "@plugjs/typescript": "^0.5.9"
       },
       "bin": {
         "bootstrap-plugjs-build": "dist/bootstrap.mjs"
       }
     },
     "node_modules/@plugjs/cov8": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@plugjs/cov8/-/cov8-0.5.7.tgz",
-      "integrity": "sha512-46trGhfQy6W0WFhy22gNDWcuPEU2W6xUznKhvYgZv+ZHDtwFIwzcwQSC/FR4O3atc1ie7GV17mLljUMuRfHU+w==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@plugjs/cov8/-/cov8-0.5.9.tgz",
+      "integrity": "sha512-v37fhhxxDUPFtssGn3sYpHBmmwg/nVjazPGgci+FC+yitQw/w2DOXbMhYNFUE8xXWosBgSDQLkBHSkCgmg0zBA==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.23.0",
         "@babel/types": "^7.23.0",
-        "@plugjs/cov8-html": "^0.1.31",
+        "@plugjs/cov8-html": "^0.1.34",
         "source-map": "^0.7.4"
       },
       "bin": {
         "cov8": "dist/cli.mjs"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.5.7"
+        "@plugjs/plug": "0.5.9"
       }
     },
     "node_modules/@plugjs/cov8-html": {
-      "version": "0.1.33",
-      "resolved": "https://registry.npmjs.org/@plugjs/cov8-html/-/cov8-html-0.1.33.tgz",
-      "integrity": "sha512-mUY081e0qikTordguR31UuG5NW61QkRByxK2GGm20606NysZK6zGdCIhvA6XjnVG20Pb5jHImbZ3VEL5ygEM7w==",
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/@plugjs/cov8-html/-/cov8-html-0.1.34.tgz",
+      "integrity": "sha512-+AmC6IJIk//fEr7uHnPTqZQmcYJX80RvAlVpW3NCsOEpoAc1w+aUDVUXlw+McqwSPqDmtRCQETltZxkD5FDeZg==",
       "dev": true
     },
     "node_modules/@plugjs/eslint": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@plugjs/eslint/-/eslint-0.5.7.tgz",
-      "integrity": "sha512-nLf9kHeYNFkcJyNW+iM62eBDp30bmSzl20U/leBFQeM849kNzY2xi3seIa06roegLCaGibTnl5Fn/RSGCkcJWQ==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@plugjs/eslint/-/eslint-0.5.9.tgz",
+      "integrity": "sha512-4P7xFI80ux5YX2b2nKTl6QufhB0va+KqCdE8G2aBVukPO47H6s2kYbkqBRokPDgaWqpL/P6+RJMR/Llsc4b9mw==",
       "dev": true,
       "dependencies": {
-        "eslint": "^8.50.0"
+        "eslint": "^8.51.0"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.5.7"
+        "@plugjs/plug": "0.5.9"
       }
     },
     "node_modules/@plugjs/eslint-plugin": {
@@ -796,26 +796,26 @@
       }
     },
     "node_modules/@plugjs/expect5": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@plugjs/expect5/-/expect5-0.5.7.tgz",
-      "integrity": "sha512-MDoiugJGBGFbEN2ijYSNT0/uYzZA/ZFks6WSuKD0q8wVAcyZ6dXz7jjltiAaw0gPMtzcLx/ZcwIRNsCKTiHS0g==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@plugjs/expect5/-/expect5-0.5.9.tgz",
+      "integrity": "sha512-y09XLMONvNOy3/QbB60WEEEI70q8W2zRa9bECuHmrUtnOtaHjB0cR4xYQxIMAxvrYGH4Ppsdhcw2DUlBi0Fd7g==",
       "dev": true,
       "bin": {
         "expect5": "dist/cli.mjs"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.5.7"
+        "@plugjs/plug": "0.5.9"
       }
     },
     "node_modules/@plugjs/plug": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@plugjs/plug/-/plug-0.5.7.tgz",
-      "integrity": "sha512-1VXi1Hdkcg2HEyIJu30T+PTLcISLzYc0YMKjhA/Yy4vOB2HonAqeY2cGhzRwNHtEP2bLYHn2xHQXGCILdjncAg==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@plugjs/plug/-/plug-0.5.9.tgz",
+      "integrity": "sha512-V7ktACqkwStCRmZCkekZOrsFK1hWxzrBJ2Tuza8rfcNRbGN21773bfMwn5Sm0ZVXjgrsWXhX/+Zz7fe+Gwdhbg==",
       "dev": true,
       "dependencies": {
-        "@plugjs/tsrun": "^0.4.23",
+        "@plugjs/tsrun": "^0.4.25",
         "@types/node": "<19",
-        "esbuild": "^0.19.4",
+        "esbuild": "^0.19.5",
         "jsonc-parser": "^3.2.0",
         "picomatch": "^2.3.1"
       },
@@ -824,39 +824,39 @@
       }
     },
     "node_modules/@plugjs/tsd": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@plugjs/tsd/-/tsd-0.5.7.tgz",
-      "integrity": "sha512-Ec5xGMEvOQFidZrDqRVJhr8XfiIykPMoEseC57InkOVAcN5T3INvoLxU89/e8Bgm+8W4FhSlnGNkHZKAwETDzg==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@plugjs/tsd/-/tsd-0.5.9.tgz",
+      "integrity": "sha512-EHDVOcI2SdZy8wLTPF0Q5BcjQu3JqC9j1lo/u6gRcTfynDe2Ab6jD0y9K/yEOQ2EqLRacGK3SOiNxJVHBGq2Xw==",
       "dev": true,
       "dependencies": {
         "tsd": "^0.29.0"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.5.7"
+        "@plugjs/plug": "0.5.9"
       }
     },
     "node_modules/@plugjs/tsrun": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/@plugjs/tsrun/-/tsrun-0.4.24.tgz",
-      "integrity": "sha512-coi20cndetXJJN5wacTSBXcN01y1qFFdjczLwqymsKarnEEgBsjHD9B7BxkfNeNFr4FZ0JjPLsfBp5s5b3AqUA==",
+      "version": "0.4.25",
+      "resolved": "https://registry.npmjs.org/@plugjs/tsrun/-/tsrun-0.4.25.tgz",
+      "integrity": "sha512-ItewCsIdlsPXEFYt/1aU1hZTnJAEzsHI3Tm37f0aLEOswii+VDkyBw1m5tFULErno1ebh+aN62GqJROD+rHK9Q==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.19.4"
+        "esbuild": "^0.19.5"
       },
       "bin": {
         "tsrun": "dist/tsrun.mjs"
       }
     },
     "node_modules/@plugjs/typescript": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@plugjs/typescript/-/typescript-0.5.7.tgz",
-      "integrity": "sha512-tuo5GZvwQnDQ8VOkh2gqCvfSCODbBJUVPSft2xKauYMW/PYP47nMO2S65Q59NCo7o1Cp5+1hmpo6+pn3w41rJg==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@plugjs/typescript/-/typescript-0.5.9.tgz",
+      "integrity": "sha512-DBK9amMFTzpQyjfmrtdkDdALRr1tLJznRRnig1BAcmzI+8JcDV2qmQwju40KMT1u7Cs6+4Pmfd/RQ3/iYm/aAA==",
       "dev": true,
       "dependencies": {
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.5.7"
+        "@plugjs/plug": "0.5.9"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -934,17 +934,17 @@
       "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.8.0.tgz",
-      "integrity": "sha512-GosF4238Tkes2SHPQ1i8f6rMtG6zlKwMEB0abqSJ3Npvos+doIlc/ATG+vX1G9coDF3Ex78zM3heXHLyWEwLUw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.0.tgz",
+      "integrity": "sha512-lgX7F0azQwRPB7t7WAyeHWVfW1YJ9NIgd9mvGhfQpRY56X6AVf8mwM8Wol+0z4liE7XX3QOt8MN1rUKCfSjRIA==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.8.0",
-        "@typescript-eslint/type-utils": "6.8.0",
-        "@typescript-eslint/utils": "6.8.0",
-        "@typescript-eslint/visitor-keys": "6.8.0",
+        "@typescript-eslint/scope-manager": "6.9.0",
+        "@typescript-eslint/type-utils": "6.9.0",
+        "@typescript-eslint/utils": "6.9.0",
+        "@typescript-eslint/visitor-keys": "6.9.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -970,16 +970,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.8.0.tgz",
-      "integrity": "sha512-5tNs6Bw0j6BdWuP8Fx+VH4G9fEPDxnVI7yH1IAPkQH5RUtvKwRoqdecAPdQXv4rSOADAaz1LFBZvZG7VbXivSg==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.0.tgz",
+      "integrity": "sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.8.0",
-        "@typescript-eslint/types": "6.8.0",
-        "@typescript-eslint/typescript-estree": "6.8.0",
-        "@typescript-eslint/visitor-keys": "6.8.0",
+        "@typescript-eslint/scope-manager": "6.9.0",
+        "@typescript-eslint/types": "6.9.0",
+        "@typescript-eslint/typescript-estree": "6.9.0",
+        "@typescript-eslint/visitor-keys": "6.9.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -999,14 +999,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.8.0.tgz",
-      "integrity": "sha512-xe0HNBVwCph7rak+ZHcFD6A+q50SMsFwcmfdjs9Kz4qDh5hWhaPhFjRs/SODEhroBI5Ruyvyz9LfwUJ624O40g==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.0.tgz",
+      "integrity": "sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.8.0",
-        "@typescript-eslint/visitor-keys": "6.8.0"
+        "@typescript-eslint/types": "6.9.0",
+        "@typescript-eslint/visitor-keys": "6.9.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1017,14 +1017,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.8.0.tgz",
-      "integrity": "sha512-RYOJdlkTJIXW7GSldUIHqc/Hkto8E+fZN96dMIFhuTJcQwdRoGN2rEWA8U6oXbLo0qufH7NPElUb+MceHtz54g==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.9.0.tgz",
+      "integrity": "sha512-XXeahmfbpuhVbhSOROIzJ+b13krFmgtc4GlEuu1WBT+RpyGPIA4Y/eGnXzjbDj5gZLzpAXO/sj+IF/x2GtTMjQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.8.0",
-        "@typescript-eslint/utils": "6.8.0",
+        "@typescript-eslint/typescript-estree": "6.9.0",
+        "@typescript-eslint/utils": "6.9.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -1045,9 +1045,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.8.0.tgz",
-      "integrity": "sha512-p5qOxSum7W3k+llc7owEStXlGmSl8FcGvhYt8Vjy7FqEnmkCVlM3P57XQEGj58oqaBWDQXbJDZxwUWMS/EAPNQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.0.tgz",
+      "integrity": "sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -1059,14 +1059,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.8.0.tgz",
-      "integrity": "sha512-ISgV0lQ8XgW+mvv5My/+iTUdRmGspducmQcDw5JxznasXNnZn3SKNrTRuMsEXv+V/O+Lw9AGcQCfVaOPCAk/Zg==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.0.tgz",
+      "integrity": "sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.8.0",
-        "@typescript-eslint/visitor-keys": "6.8.0",
+        "@typescript-eslint/types": "6.9.0",
+        "@typescript-eslint/visitor-keys": "6.9.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1087,18 +1087,18 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.8.0.tgz",
-      "integrity": "sha512-dKs1itdE2qFG4jr0dlYLQVppqTE+Itt7GmIf/vX6CSvsW+3ov8PbWauVKyyfNngokhIO9sKZeRGCUo1+N7U98Q==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.9.0.tgz",
+      "integrity": "sha512-5Wf+Jsqya7WcCO8me504FBigeQKVLAMPmUzYgDbWchINNh1KJbxCgVya3EQ2MjvJMVeXl3pofRmprqX6mfQkjQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.8.0",
-        "@typescript-eslint/types": "6.8.0",
-        "@typescript-eslint/typescript-estree": "6.8.0",
+        "@typescript-eslint/scope-manager": "6.9.0",
+        "@typescript-eslint/types": "6.9.0",
+        "@typescript-eslint/typescript-estree": "6.9.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1113,13 +1113,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.8.0.tgz",
-      "integrity": "sha512-oqAnbA7c+pgOhW2OhGvxm0t1BULX5peQI/rLsNDpGM78EebV3C9IGbX5HNZabuZ6UQrYveCLjKo8Iy/lLlBkkg==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.0.tgz",
+      "integrity": "sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.8.0",
+        "@typescript-eslint/types": "6.9.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -1129,6 +1129,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -1412,13 +1418,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+      "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.1",
+        "set-function-length": "^1.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1741,26 +1748,26 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.2.tgz",
-      "integrity": "sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==",
+      "version": "1.22.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
+      "integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
       "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
         "arraybuffer.prototype.slice": "^1.0.2",
         "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.5",
         "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
         "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.1",
+        "get-intrinsic": "^1.2.2",
         "get-symbol-description": "^1.0.0",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
-        "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0",
         "internal-slot": "^1.0.5",
         "is-array-buffer": "^3.0.2",
         "is-callable": "^1.2.7",
@@ -1770,7 +1777,7 @@
         "is-string": "^1.0.7",
         "is-typed-array": "^1.1.12",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.3",
+        "object-inspect": "^1.13.1",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.5.1",
@@ -1784,7 +1791,7 @@
         "typed-array-byte-offset": "^1.0.0",
         "typed-array-length": "^1.0.4",
         "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.11"
+        "which-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1794,26 +1801,26 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
-      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
+      "integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.3",
-        "has": "^1.0.3",
-        "has-tostringtag": "^1.0.0"
+        "get-intrinsic": "^1.2.2",
+        "has-tostringtag": "^1.0.0",
+        "hasown": "^2.0.0"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-shim-unscopables": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+      "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
       "dev": true,
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       }
     },
     "node_modules/es-to-primitive": {
@@ -1883,18 +1890,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.51.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
-      "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
+      "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.51.0",
-        "@humanwhocodes/config-array": "^0.11.11",
+        "@eslint/js": "8.52.0",
+        "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -2042,26 +2050,26 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
-      "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
+      "integrity": "sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.findlastindex": "^1.2.2",
-        "array.prototype.flat": "^1.3.1",
-        "array.prototype.flatmap": "^1.3.1",
+        "array-includes": "^3.1.7",
+        "array.prototype.findlastindex": "^1.2.3",
+        "array.prototype.flat": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.2",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-import-resolver-node": "^0.3.9",
         "eslint-module-utils": "^2.8.0",
-        "has": "^1.0.3",
-        "is-core-module": "^2.13.0",
+        "hasown": "^2.0.0",
+        "is-core-module": "^2.13.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.6",
-        "object.groupby": "^1.0.0",
-        "object.values": "^1.1.6",
+        "object.fromentries": "^2.0.7",
+        "object.groupby": "^1.0.1",
+        "object.values": "^1.1.7",
         "semver": "^6.3.1",
         "tsconfig-paths": "^3.14.2"
       },
@@ -2403,15 +2411,15 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
+        "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2560,15 +2568,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -2588,12 +2587,12 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.1"
+        "get-intrinsic": "^1.2.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2636,6 +2635,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hosted-git-info": {
@@ -2704,13 +2715,13 @@
       "dev": true
     },
     "node_modules/internal-slot": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
-      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
+      "integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.2.0",
-        "has": "^1.0.3",
+        "get-intrinsic": "^1.2.2",
+        "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
       },
       "engines": {
@@ -2802,12 +2813,12 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "dev": true,
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3395,9 +3406,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.0.tgz",
-      "integrity": "sha512-HQ4J+ic8hKrgIt3mqk6cVOVrW2ozL4KdvHlqpBv9vDYWx9ysAgENAdvy4FoGF+KFdhR7nQTNm5J0ctAeOwn+3g==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4029,6 +4040,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+      "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.1",
+        "get-intrinsic": "^1.2.1",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/set-function-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
@@ -4537,13 +4563,13 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+      "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
       "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.4",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,6 @@
       "devDependencies": {
         "@plugjs/build": "^0.5.9",
         "@plugjs/tsd": "^0.5.9",
-        "@types/chai": "^4.3.9",
-        "chai": "^4.3.10",
         "typescript": "^5.2.2"
       }
     },
@@ -874,12 +872,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/@types/chai": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.9.tgz",
-      "integrity": "sha512-69TtiDzu0bcmKQv3yg1Zx409/Kd7r0b5F1PfpYJfSHzLGtB53547V4u+9iqKYsTu/O2ai6KTb0TInNpvuQ3qmg==",
-      "dev": true
-    },
     "node_modules/@types/eslint": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
@@ -1356,15 +1348,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -1466,24 +1449,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/chai": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
-      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
-      "dev": true,
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1498,18 +1463,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ci-info": {
@@ -1635,18 +1588,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2399,15 +2340,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3208,15 +3140,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dev": true,
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -3622,15 +3545,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/picomatch": {
@@ -4396,15 +4310,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "justus",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A JavaScript validation library, with types!",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -78,8 +78,8 @@
   "author": "Juit Developers <developers@juit.com>",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@plugjs/build": "^0.5.7",
-    "@plugjs/tsd": "^0.5.7",
+    "@plugjs/build": "^0.5.9",
+    "@plugjs/tsd": "^0.5.9",
     "@types/chai": "^4.3.9",
     "chai": "^4.3.10",
     "typescript": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -80,8 +80,6 @@
   "devDependencies": {
     "@plugjs/build": "^0.5.9",
     "@plugjs/tsd": "^0.5.9",
-    "@types/chai": "^4.3.9",
-    "chai": "^4.3.10",
     "typescript": "^5.2.2"
   },
   "directories": {

--- a/src/dts-generator.ts
+++ b/src/dts-generator.ts
@@ -29,8 +29,8 @@ import type { Validation, Validator } from './types'
 /** Check that two of our generated types are equal */
 function typeEqual(a: TypeNode, b: TypeNode): boolean {
   function eq(a: any, b: any): boolean {
-    if ((typeof a == 'object' && a != null) &&
-        (typeof b == 'object' && b != null) ) {
+    if ((typeof a === 'object' && a != null) &&
+        (typeof b === 'object' && b != null) ) {
       for (const key in a) {
         if (! eq(a[key], b[key])) return false
       }
@@ -611,7 +611,7 @@ registerTypeGenerator(ObjectValidator, (validator, references, isInput) => {
         propertyType, // type
         undefined) // members
 
-    if (properties.length == 0) return extra
+    if (properties.length === 0) return extra
 
     const type = ts.factory.createTypeLiteralNode(properties)
     return ts.factory.createIntersectionTypeNode([ type, extra ])

--- a/src/extra/arn.ts
+++ b/src/extra/arn.ts
@@ -42,7 +42,7 @@ function parse<Service extends string, ResourceType extends string>(
     service?: Service,
     type?: ResourceType,
 ): ParsedArn<Service, ResourceType> {
-  assertValidation(typeof value == 'string', 'Value is not a "string"')
+  assertValidation(typeof value === 'string', 'Value is not a "string"')
 
   const segments = value.split(':')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,3 +82,20 @@ export function strip<V extends Validation>(
 
   return getValidator(validation).validate(value, opts)
 }
+
+/**
+ * Validate a _value_ using the specified `Validation`, automatically stripping
+ * additional properties and optional `null`s (but not forbidden ones), and
+ * treating all properties as optional.
+ *
+ * This is equivalent to setting the `partialValidation` option to `true` in
+ * `validate(...)`, but this function correctly represents the returned type as
+ * a `Partial<...>` type.
+ */
+export function partial<V extends Validation>(
+    validation: V,
+    value: any,
+    options?: ValidationOptions,
+): Partial<InferValidation<V>> {
+  return getValidator(validation).validate(value, { ...options, partialValidation: true })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,6 @@ export type { TupleMember } from './validators/tuple'
  * VALIDATE FUNCTION (our main entry point)                                   *
  * ========================================================================== */
 
-import { defaultValidationOptions } from './types'
 import { getValidator } from './utilities'
 
 import type { InferValidation, Validation, ValidationOptions } from './types'
@@ -51,7 +50,7 @@ export function validate<V extends Validation>(
     value: any,
     options?: ValidationOptions,
 ): InferValidation<V> {
-  const opts: ValidationOptions = { ...defaultValidationOptions, ...options }
+  const opts: ValidationOptions = { ...options }
   return getValidator(validation).validate(value, opts)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export * from './utilities'
 // Validators
 export { AnyValidator, any } from './validators/any'
 export { AnyArrayValidator, ArrayValidator, array, arrayOf } from './validators/array'
+export { AnyBigIntValidator, BigIntValidator, bigint } from './validators/bigint'
 export { BooleanValidator, boolean } from './validators/boolean'
 export { ConstantValidator, constant } from './validators/constant'
 export { DateValidator, date } from './validators/date'
@@ -24,6 +25,7 @@ export { AllOfValidator, OneOfValidator, allOf, oneOf } from './validators/union
 
 // Validator Types
 export type { ArrayConstraints, arrayFactory } from './validators/array'
+export type { BrandedBigIntConstraints, bigintFactory } from './validators/bigint'
 export type { BooleanConstraints, booleanFactory } from './validators/boolean'
 export type { DateConstraints, dateFactory } from './validators/date'
 export type { BrandedNumberConstraints, numberFactory } from './validators/number'

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,8 @@ export interface ValidationOptions {
   stripOptionalNulls?: boolean,
   /** Ignore and strip forbidden (`never`) properties from objects (default: `false`) */
   stripForbiddenProperties?: boolean,
+  /**  Perform a _partial_ validation, treating all properties as optional (default: `false`) */
+  partialValidation?: boolean,
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,15 +37,6 @@ export interface ValidationOptions {
 }
 
 /**
- * Default validation options.
- */
-export const defaultValidationOptions: Readonly<Required<ValidationOptions>> = {
-  stripAdditionalProperties: false,
-  stripForbiddenProperties: false,
-  stripOptionalNulls: false,
-}
-
-/**
  * A `Validator` is an object capable of validating a given _value_ and
  * (possibly) converting it the required type `T`.
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,13 +110,13 @@ implements Validator<T, I>, Iterable<TupleRestParameter<T, I>> {
  * Those are:
  *
  * * A `Validator` instance or a _zero-arguments_ function returning one
- * * A `Tuple` or a `Schema`, validated as arrays or object
- * * Either `null`, a `boolean`, a `number` or a `string` for constants
+ * * A `Tuple` or a `Schema`, validated as arrays or objects
+ * * Either `null`, a `boolean`, a `number`, a `bigint` or a `string` for constants
  */
 export type Validation =
   Validator | // Validator instances
   Tuple | Schema | // Tuples or schemas (arrays, objects)
-  null | boolean | number | string // Primitives, mapped as constants
+  null | boolean | bigint | number | string // Primitives, mapped as constants
 
 /**
  * Infer the type returned by a `Validation` when validating.
@@ -128,6 +128,7 @@ export type InferValidation<V> =
   // Primitives are returned as constants
   V extends undefined ? V :
   V extends boolean ? V :
+  V extends bigint ? V :
   V extends number ? V :
   V extends string ? V :
   V extends null ? V :
@@ -148,6 +149,7 @@ export type InferInput<V> =
   // Primitives are returned as constants
   V extends undefined ? V :
   V extends boolean ? V :
+  V extends bigint ? V :
   V extends number ? V :
   V extends string ? V :
   V extends null ? V :

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -23,6 +23,7 @@ export function getValidator(validation: Validation): Validator {
   switch (typeof validation) {
     // constants
     case 'boolean':
+    case 'bigint':
     case 'string':
     case 'number':
       return new (registry.get('constant'))(validation)

--- a/src/validators/bigint.ts
+++ b/src/validators/bigint.ts
@@ -1,0 +1,147 @@
+import { assertSchema, assertValidation, ValidationError } from '../errors'
+import { AbstractValidator, makeValidatorFactory } from '../types'
+
+import type { Branding, Validator } from '../types'
+
+/* ========================================================================== */
+
+/** Constraints to validate a `bigint` with. */
+export interface BigIntConstraints {
+  /** The value for which a `bigint` must be multiple of for it to be valid */
+  multipleOf?: bigint | number,
+  /** The _inclusive_ maximum value for a valid `bigint`: `value <= maximum` */
+  maximum?: bigint | number,
+  /** The _inclusive_ minimum value for a valid `bigint`: `value >= minimum` */
+  minimum?: bigint | number,
+  /** The _exclusive_ maximum value for a valid `bigint`: `value < exclusiveMaximum` */
+  exclusiveMaximum?: bigint | number,
+  /** The _exclusive_ minimum value for a valid `bigint`: `value > exclusiveMaximum` */
+  exclusiveMinimum?: bigint | number,
+  /** Allow bigints to be parsed from strings (e.g. `123.456` or `0x0CAFE`, default: `false`) */
+  fromString?: boolean,
+  /** Allow bigints to be parsed from numbers (default: `true`) */
+  fromNumber?: boolean,
+}
+
+/** Constraints to validate a `bigint` with extra branding information. */
+export interface BrandedBigIntConstraints<B extends string> extends BigIntConstraints {
+  /** The _brand_ of the string (will generate a `__brand_${B}` type property */
+  brand: B
+}
+
+/** A `Validator` validating any `bigint`. */
+export class AnyBigIntValidator extends AbstractValidator<bigint> {
+  validate(value: unknown): bigint {
+    if (typeof value === 'number') {
+      try {
+        value = BigInt(value)
+      } catch (error) {
+        throw new ValidationError('BigInt can not be parsed from number')
+      }
+    }
+    assertValidation(typeof value === 'bigint', 'Value is not a "bigint"')
+    return value
+  }
+}
+
+/** A `Validator` validating `bigint`s with constaints. */
+export class BigIntValidator<N extends bigint = bigint> extends AbstractValidator<N, bigint> {
+  readonly fromString: boolean
+  readonly fromNumber: boolean
+  readonly exclusiveMaximum?: bigint
+  readonly exclusiveMinimum?: bigint
+  readonly maximum?: bigint
+  readonly minimum?: bigint
+  readonly multipleOf?: bigint
+  readonly brand?: string
+
+  constructor(constraints: BigIntConstraints = {}) {
+    super()
+
+    const {
+      exclusiveMaximum,
+      exclusiveMinimum,
+      maximum,
+      minimum,
+      multipleOf,
+      fromString = false,
+      fromNumber = true,
+    } = constraints
+
+    if ('brand' in constraints) this.brand = (<any> constraints).brand
+    this.fromString = fromString
+    this.fromNumber = fromNumber
+
+    const _exclusiveMaximum = exclusiveMaximum === undefined ? undefined : BigInt(exclusiveMaximum)
+    const _exclusiveMinimum = exclusiveMinimum === undefined ? undefined : BigInt(exclusiveMinimum)
+    const _maximum = maximum === undefined ? undefined : BigInt(maximum)
+    const _minimum = minimum === undefined ? undefined : BigInt(minimum)
+    const _multipleOf = multipleOf === undefined ? undefined : BigInt(multipleOf)
+
+    if ((_maximum !== undefined) && (_minimum !== undefined)) {
+      assertSchema(_maximum >= _minimum, `Constraint "minimum" (${_minimum}) is greater than "maximum" (${_maximum})`)
+    }
+
+    if ((_exclusiveMaximum !== undefined) && (_minimum !== undefined)) {
+      assertSchema(_exclusiveMaximum > _minimum,
+          `Constraint "exclusiveMaximum" (${_exclusiveMaximum}) must be greater than "minimum" (${_minimum})`)
+    }
+
+    if ((_exclusiveMinimum !== undefined) && (_maximum != undefined)) {
+      assertSchema(_maximum > _exclusiveMinimum,
+          `Constraint "maximum" (${_maximum}) must be greater than "exclusiveMinimum" (${_exclusiveMinimum})`)
+    }
+
+    if ((_exclusiveMinimum != undefined) && (_exclusiveMaximum !== undefined)) {
+      assertSchema(_exclusiveMaximum > _exclusiveMinimum,
+          `Constraint "exclusiveMaximum" (${_exclusiveMaximum}) must be greater than "exclusiveMinimum" (${_exclusiveMinimum})`)
+    }
+
+    if (_multipleOf !== undefined) {
+      assertSchema(_multipleOf > 0, `Constraint "multipleOf" (${_multipleOf}) must be greater than zero`)
+    }
+
+    this.exclusiveMaximum = _exclusiveMaximum
+    this.exclusiveMinimum = _exclusiveMinimum
+    this.maximum = _maximum
+    this.minimum = _minimum
+    this.multipleOf = _multipleOf
+  }
+
+  validate(value: unknown): N {
+    // Allow parsing from strings or numbers
+    if (((typeof value === 'string') && (this.fromString)) ||
+        ((typeof value === 'number') && (this.fromNumber))) {
+      try {
+        value = BigInt(value)
+      } catch (error) {
+        throw new ValidationError('BigInt can not be parsed from ' + typeof value)
+      }
+    }
+
+    assertValidation(typeof value === 'bigint', 'Value is not a "bigint"')
+
+    assertValidation(((this.minimum === undefined) || (value >= this.minimum)),
+        `BigInt is less than ${this.minimum}`)
+    assertValidation(((this.maximum === undefined) || (value <= this.maximum)),
+        `BigInt is greater than ${this.maximum}`)
+    assertValidation((this.exclusiveMinimum === undefined) || (value > this.exclusiveMinimum),
+        `BigInt is less than or equal to ${this.exclusiveMinimum}`)
+    assertValidation((this.exclusiveMaximum === undefined) || (value < this.exclusiveMaximum),
+        `BigInt is greater than or equal to ${this.exclusiveMaximum}`)
+    assertValidation((this.multipleOf === undefined) || (!(value % this.multipleOf)),
+        `BigInt is not a multiple of ${this.multipleOf}`)
+
+    return value as N
+  }
+}
+
+export function bigintFactory(constraints: BigIntConstraints): BigIntValidator<bigint>
+export function bigintFactory<N extends bigint>(constraints: BigIntConstraints): BigIntValidator<N>
+export function bigintFactory<B extends string>(constraints: BrandedBigIntConstraints<B>): BigIntValidator<bigint & Branding<B>>
+export function bigintFactory(constraints: BigIntConstraints): Validator<bigint> {
+  return new BigIntValidator(constraints)
+}
+
+/** Validate `bigint`s. */
+export const bigint = makeValidatorFactory(new AnyBigIntValidator(), bigintFactory)

--- a/src/validators/boolean.ts
+++ b/src/validators/boolean.ts
@@ -25,7 +25,7 @@ export class BooleanValidator extends AbstractValidator<boolean> {
 
   validate(value: unknown): boolean {
     // Allow parsing from strings
-    if ((typeof value == 'string') && (this.fromString)) {
+    if ((typeof value === 'string') && (this.fromString)) {
       const string = value.toLowerCase()
       const parsed = string === 'true' ? true : string === 'false' ? false : undefined
       assertValidation(parsed !== undefined, 'Boolean can not be parsed from string')

--- a/src/validators/constant.ts
+++ b/src/validators/constant.ts
@@ -5,7 +5,7 @@ import { AbstractValidator } from '../types'
 import type { Validator } from '../types'
 
 /** A `Validator` for _constants_. */
-export class ConstantValidator<T extends string | number | boolean | null> extends AbstractValidator<T> {
+export class ConstantValidator<T extends string | number | boolean | bigint | null> extends AbstractValidator<T> {
   readonly constant: T
 
   constructor(constant: T) {
@@ -20,7 +20,7 @@ export class ConstantValidator<T extends string | number | boolean | null> exten
 }
 
 /** Validate _constants_. */
-export function constant<T extends string | number | boolean | null>(constant: T): Validator<T> {
+export function constant<T extends string | number | boolean | bigint | null>(constant: T): Validator<T> {
   return new ConstantValidator(constant)
 }
 

--- a/src/validators/constant.ts
+++ b/src/validators/constant.ts
@@ -14,7 +14,8 @@ export class ConstantValidator<T extends string | number | boolean | bigint | nu
   }
 
   validate(value: unknown): T {
-    assertValidation(value === this.constant, `Value does not match constant "${this.constant}"`)
+    const extra = this.constant === null ? '' : ` (${typeof this.constant})`
+    assertValidation(value === this.constant, `Value does not match constant "${this.constant}"${extra}`)
     return value as T
   }
 }

--- a/src/validators/never.ts
+++ b/src/validators/never.ts
@@ -1,5 +1,5 @@
 import { ValidationError } from '../errors'
-import { AbstractValidator, defaultValidationOptions } from '../types'
+import { AbstractValidator } from '../types'
 
 import type { ValidationOptions } from '../types'
 
@@ -7,7 +7,7 @@ import type { ValidationOptions } from '../types'
 export class NeverValidator extends AbstractValidator<never> {
   optional: true = true
 
-  validate(value: unknown, options: ValidationOptions = defaultValidationOptions): never {
+  validate(value: unknown, options: ValidationOptions = {}): never {
     const { stripForbiddenProperties } = options
 
     // @ts-expect-error

--- a/src/validators/number.ts
+++ b/src/validators/number.ts
@@ -46,7 +46,7 @@ export interface BrandedNumberConstraints<B extends string> extends NumberConstr
 /** A `Validator` validating any `number`. */
 export class AnyNumberValidator extends AbstractValidator<number> {
   validate(value: unknown): number {
-    assertValidation(typeof value == 'number', 'Value is not a "number"')
+    assertValidation(typeof value === 'number', 'Value is not a "number"')
     assertValidation(! isNaN(value), 'Number is "NaN"')
     return value
   }
@@ -131,13 +131,13 @@ export class NumberValidator<N extends number = number> extends AbstractValidato
 
   validate(value: unknown): N {
     // Allow parsing from strings
-    if ((typeof value == 'string') && (this.fromString)) {
+    if ((typeof value === 'string') && (this.fromString)) {
       const parsed = +`${value}`
       assertValidation(! isNaN(parsed), 'Number can not be parsed from string')
       value = parsed
     }
 
-    assertValidation(typeof value == 'number', 'Value is not a "number"')
+    assertValidation(typeof value === 'number', 'Value is not a "number"')
 
     if (isNaN(value)) {
       assertValidation(this.allowNaN, 'Number is "NaN"')
@@ -147,10 +147,10 @@ export class NumberValidator<N extends number = number> extends AbstractValidato
     assertValidation(value >= this.minimum, `Number is less than ${this.minimum}`)
     assertValidation(value <= this.maximum, `Number is greater than ${this.maximum}`)
 
-    assertValidation((this.exclusiveMinimum == undefined) || (value > this.exclusiveMinimum),
+    assertValidation((this.exclusiveMinimum === undefined) || (value > this.exclusiveMinimum),
         `Number is less than or equal to ${this.exclusiveMinimum}`)
 
-    assertValidation((this.exclusiveMaximum == undefined) || (value < this.exclusiveMaximum),
+    assertValidation((this.exclusiveMaximum === undefined) || (value < this.exclusiveMaximum),
         `Number is greater than or equal to ${this.exclusiveMaximum}`)
 
     assertValidation(this.#isMultipleOf ? this.#isMultipleOf(value) : true,

--- a/src/validators/object.ts
+++ b/src/validators/object.ts
@@ -1,6 +1,6 @@
 import { assertValidation, ValidationErrorBuilder } from '../errors'
 import { registry } from '../registry'
-import { AbstractValidator, defaultValidationOptions, makeValidatorFactory } from '../types'
+import { AbstractValidator, makeValidatorFactory } from '../types'
 import { getValidator } from '../utilities'
 
 import type {
@@ -43,7 +43,7 @@ export class ObjectValidator<S extends Schema> extends AbstractValidator<InferSc
     this.schema = schema
   }
 
-  validate(value: unknown, options: ValidationOptions = defaultValidationOptions): InferSchema<S> {
+  validate(value: unknown, options: ValidationOptions = {}): InferSchema<S> {
     assertValidation(typeof value === 'object', 'Value is not an "object"')
     assertValidation(value !== null, 'Value is "null"')
 
@@ -75,7 +75,6 @@ export class ObjectValidator<S extends Schema> extends AbstractValidator<InferSc
         } catch (error) {
           if (optional) continue // original was undefined, so we can skip!
           builder.record('Required property missing', key)
-          // builder.record(error, key) // double error!
         }
 
         continue

--- a/src/validators/object.ts
+++ b/src/validators/object.ts
@@ -47,7 +47,7 @@ export class ObjectValidator<S extends Schema> extends AbstractValidator<InferSc
     assertValidation(typeof value === 'object', 'Value is not an "object"')
     assertValidation(value !== null, 'Value is "null"')
 
-    const { stripAdditionalProperties, stripOptionalNulls } = options
+    const { stripAdditionalProperties, stripOptionalNulls, partialValidation } = options
 
     const record: { [ k in string | number | symbol ]?: unknown } = value
     const builder = new ValidationErrorBuilder()
@@ -63,10 +63,12 @@ export class ObjectValidator<S extends Schema> extends AbstractValidator<InferSc
       }
 
       // if we have no value, then we have few possibilities:
+      // - we are performing a partial validation, so we ignore
       // - the (optional) validator provides a valid value
       // - the validator is optional, so we can simply ignore
       // - the validator is not optional, so the property is missing
       if (original === undefined) {
+        if (partialValidation) continue
         try {
           // try to validate, the validator _might_ be giving us a value
           const validated = validator.validate(original, options)

--- a/src/validators/object.ts
+++ b/src/validators/object.ts
@@ -17,7 +17,7 @@ import type {
 /** A `Validator` validating any `object`. */
 export class AnyObjectValidator extends AbstractValidator<Record<string, any>> {
   validate(value: unknown): Record<string, any> {
-    assertValidation(typeof value == 'object', 'Value is not an "object"')
+    assertValidation(typeof value === 'object', 'Value is not an "object"')
     assertValidation(value !== null, 'Value is "null"')
     return value
   }
@@ -73,7 +73,7 @@ export class ObjectValidator<S extends Schema> extends AbstractValidator<InferSc
           // try to validate, the validator _might_ be giving us a value
           const validated = validator.validate(original, options)
           // put the validated value in the clone, unless optional and undefined
-          if (! (optional && (validated == undefined))) clone[key] = validated
+          if (! (optional && (validated === undefined))) clone[key] = validated
         } catch (error) {
           if (optional) continue // original was undefined, so we can skip!
           builder.record('Required property missing', key)
@@ -86,7 +86,7 @@ export class ObjectValidator<S extends Schema> extends AbstractValidator<InferSc
       try {
         const validated = validator.validate(original, options)
         // put the validated value in the clone, unless optional and undefined
-        if (! (optional && (validated == undefined))) clone[key] = validated
+        if (! (optional && (validated === undefined))) clone[key] = validated
       } catch (error) {
         builder.record(error, key)
       }

--- a/src/validators/optional.ts
+++ b/src/validators/optional.ts
@@ -1,4 +1,4 @@
-import { AbstractValidator, defaultValidationOptions } from '../types'
+import { AbstractValidator } from '../types'
 import { getValidator } from '../utilities'
 
 import type { InferInput, InferValidation, Validation, ValidationOptions, Validator } from '../types'
@@ -27,7 +27,7 @@ export class OptionalValidator<
     }
 
     try {
-      this.defaultValue = validator.validate(defaultValue, defaultValidationOptions)
+      this.defaultValue = validator.validate(defaultValue, {})
     } catch (cause) {
       throw new TypeError('Default value does not match validator', { cause })
     }

--- a/src/validators/string.ts
+++ b/src/validators/string.ts
@@ -22,7 +22,7 @@ export interface BrandedStringConstraints<B extends string> extends StringConstr
 /** A `Validator` validating any `string`. */
 export class AnyStringValidator extends AbstractValidator<string> {
   validate(value: unknown): string {
-    assertValidation(typeof value == 'string', 'Value is not a "string"')
+    assertValidation(typeof value === 'string', 'Value is not a "string"')
     return value
   }
 }
@@ -55,7 +55,7 @@ export class StringValidator<S extends string = string, I = string> extends Abst
   }
 
   validate(value: unknown): S {
-    assertValidation(typeof value == 'string', 'Value is not a "string"')
+    assertValidation(typeof value === 'string', 'Value is not a "string"')
 
     assertValidation(value.length >= this.minLength,
         `String must have a minimum length of ${this.minLength}`)

--- a/test-d/00-primitives.test-d.ts
+++ b/test-d/00-primitives.test-d.ts
@@ -2,6 +2,7 @@ import { expectType, printType } from 'tsd'
 
 import {
   any,
+  bigint,
   boolean,
   constant,
   number,
@@ -16,16 +17,19 @@ expectType<any>(validate(any, null))
 expectType<boolean>(validate(boolean, null))
 expectType<number>(validate(number, null))
 expectType<string>(validate(string, null))
+expectType<bigint>(validate(bigint, null))
 
 // constructed validators
 expectType<number>(validate(number({}), null))
 expectType<string>(validate(string({}), null))
+expectType<bigint>(validate(bigint({}), null))
 
 // constants
 expectType<null>(validate(constant(null), null))
 expectType<true>(validate(constant(true), null))
 expectType<false>(validate(constant(false), null))
 expectType<12345>(validate(constant(12345), null))
+expectType<1234n>(validate(constant(1234n), null))
 expectType<'xyz'>(validate(constant('xyz'), null))
 
 // simple constants (no need for "as const")
@@ -33,15 +37,19 @@ expectType<null>(validate(null, null))
 expectType<true>(validate(true, null))
 expectType<false>(validate(false, null))
 expectType<12345>(validate(12345, null))
+expectType<1234n>(validate(1234n, null))
 expectType<'xyz'>(validate('xyz', null))
 
 // "branded" primitives
+type BrandedBigInt = bigint & { __branded_bigint: never }
 type BrandedNumber = number & { __branded_number: never }
 type BrandedString = string & { __branded_string: never }
 
+expectType<BrandedBigInt>(validate(bigint<BrandedBigInt>({}), null))
 expectType<BrandedNumber>(validate(number<BrandedNumber>({}), null))
 expectType<BrandedString>(validate(string<BrandedString>({}), null))
 
 // implicit branding
+expectType<bigint & { __brand_test: never }>(validate(bigint({ brand: 'test' }), null))
 expectType<number & { __brand_test: never }>(validate(number({ brand: 'test' }), null))
 expectType<string & { __brand_test: never }>(validate(string({ brand: 'test' }), null))

--- a/test-d/10-input.test-d.ts
+++ b/test-d/10-input.test-d.ts
@@ -5,6 +5,7 @@ import {
   any,
   array,
   arrayOf,
+  bigint,
   boolean,
   constant,
   date,
@@ -30,20 +31,23 @@ function inputType<T>(param: T): InferInput<T> {
 
 expectType<true>(inputType(true as const))
 expectType<false>(inputType(false as const))
-expectType<123>(inputType(123 as const))
-expectType<'hello'>(inputType('hello' as const))
+expectType<12345>(inputType(12345 as const))
+expectType<1234n>(inputType(1234n as const))
+expectType<'foo'>(inputType('foo' as const))
 
 expectType<undefined>(inputType(undefined))
 expectType<null>(inputType(null))
 
 expectType<true>(inputType(constant(true)))
 expectType<false>(inputType(constant(false)))
-expectType<123>(inputType(constant(123)))
-expectType<'hello'>(inputType(constant('hello')))
+expectType<12345>(inputType(constant(12345)))
+expectType<1234n>(inputType(constant(1234n)))
+expectType<'foo'>(inputType(constant('foo')))
 
 // validation _keywords_ (that is, no functions...)
 
 expectType<any>(inputType(any))
+expectType<bigint>(inputType(bigint))
 expectType<boolean>(inputType(boolean))
 expectType<Date | string | number>(inputType(date))
 expectType<never>(inputType(never))
@@ -54,6 +58,7 @@ expectType<URL | string>(inputType(url))
 
 // validation factories (keywords as functions)
 
+expectType<bigint>(inputType(bigint({})))
 expectType<boolean>(inputType(boolean({})))
 expectType<Date | string | number>(inputType(date({})))
 expectType<number>(inputType(number({})))
@@ -62,9 +67,11 @@ expectType<URL | string>(inputType(url({})))
 
 // branded numbers/strings
 
+expectType<bigint>(inputType(bigint({ brand: 'foobar' })))
 expectType<number>(inputType(number({ brand: 'foobar' })))
 expectType<string>(inputType(string({ brand: 'foobar' })))
 
+expectType<bigint & { __brand_foobar: never }>(validate(bigint({ brand: 'foobar' }), 'x'))
 expectType<number & { __brand_foobar: never }>(validate(number({ brand: 'foobar' }), 'x'))
 expectType<string & { __brand_foobar: never }>(validate(string({ brand: 'foobar' }), 'x'))
 

--- a/test/01-errors.test.ts
+++ b/test/01-errors.test.ts
@@ -1,39 +1,37 @@
-import { expect } from 'chai'
-
 import { assertSchema, assertValidation, ValidationError, ValidationErrorBuilder } from '../src'
 
 describe('Errors', () => {
   describe('ValidationError', () => {
     it('should create a validation error', () => {
       const error = new ValidationError('This is a test')
-      expect(error.message).to.equal('Found 1 validation error\n  This is a test')
-      expect(error.errors).to.eql([
+      expect(error.message).toStrictlyEqual('Found 1 validation error\n  This is a test')
+      expect(error.errors).toEqual([
         { path: [], message: 'This is a test' },
       ])
     })
 
     it('should create a validation error with a path', () => {
       const error1 = new ValidationError('This is a test', [])
-      expect(error1.message).to.equal('Found 1 validation error\n  This is a test')
-      expect(error1.errors).to.eql([
+      expect(error1.message).toStrictlyEqual('Found 1 validation error\n  This is a test')
+      expect(error1.errors).toEqual([
         { path: [], message: 'This is a test' },
       ])
 
       const error2 = new ValidationError('This is a test', [ 123 ])
-      expect(error2.message).to.equal('Found 1 validation error\n  [123]: This is a test')
-      expect(error2.errors).to.eql([
+      expect(error2.message).toStrictlyEqual('Found 1 validation error\n  [123]: This is a test')
+      expect(error2.errors).toEqual([
         { path: [ 123 ], message: 'This is a test' },
       ])
 
       const error3 = new ValidationError('This is a test', [ 'foo' ])
-      expect(error3.message).to.equal('Found 1 validation error\n  foo: This is a test')
-      expect(error3.errors).to.eql([
+      expect(error3.message).toStrictlyEqual('Found 1 validation error\n  foo: This is a test')
+      expect(error3.errors).toEqual([
         { path: [ 'foo' ], message: 'This is a test' },
       ])
 
       const error4 = new ValidationError('This is a test', [ 'foo', 'bar', 123, 456, 'baz', 789 ])
-      expect(error4.message).to.equal('Found 1 validation error\n  foo.bar[123][456].baz[789]: This is a test')
-      expect(error4.errors).to.eql([
+      expect(error4.message).toStrictlyEqual('Found 1 validation error\n  foo.bar[123][456].baz[789]: This is a test')
+      expect(error4.errors).toEqual([
         { path: [ 'foo', 'bar', 123, 456, 'baz', 789 ], message: 'This is a test' },
       ])
     })
@@ -42,8 +40,8 @@ describe('Errors', () => {
       const error0 = new ValidationError('This is a test', [ 123 ])
       const error1 = new ValidationError(error0, [ 'foo' ])
 
-      expect(error1.message).to.equal('Found 1 validation error\n  foo[123]: This is a test')
-      expect(error1.errors).to.eql([
+      expect(error1.message).toStrictlyEqual('Found 1 validation error\n  foo[123]: This is a test')
+      expect(error1.errors).toEqual([
         { path: [ 'foo', 123 ], message: 'This is a test' },
       ])
     })
@@ -56,21 +54,17 @@ describe('Errors', () => {
         return new ValidationError('This is a test', <any> constructorOrPath, <any> maybeConstructor)
       }
 
-      expect(_testCreate_().stack.match(/^\s+at\s+.*_testCreate_/gm))
-          .to.be.an('array')
-      expect(_testCreate_(_testCreate_).stack.match(/^\s+at\s+.*_testCreate_/gm))
-          .to.be.null
-      expect(_testCreate_([]).stack.match(/^\s+at\s+.*_testCreate_/gm))
-          .to.be.an('array')
-      expect(_testCreate_([], _testCreate_).stack.match(/^\s+at\s+.*_testCreate_/gm))
-          .to.be.null
+      expect(_testCreate_().stack.match(/^\s+at\s+.*_testCreate_/gm)).toBeA('array')
+      expect(_testCreate_(_testCreate_).stack.match(/^\s+at\s+.*_testCreate_/gm)).toBeNull()
+      expect(_testCreate_([]).stack.match(/^\s+at\s+.*_testCreate_/gm)).toBeA('array')
+      expect(_testCreate_([], _testCreate_).stack.match(/^\s+at\s+.*_testCreate_/gm)).toBeNull()
     })
   })
 
   describe('ValidationError Builder', () => {
     it('should not throw when no errors have been recorded', () => {
       const object = {}
-      expect(new ValidationErrorBuilder().assert(object)).to.equal(object)
+      expect(new ValidationErrorBuilder().assert(object)).toStrictlyEqual(object)
     })
 
     it('should throw when a simple error have been recorded', () => {
@@ -78,12 +72,12 @@ describe('Errors', () => {
           .record('Hello, world!')
           .record('Something else', 'myKey')
 
-      expect(() => builder.assert(null))
-          .to.throw(ValidationError, 'Found 2 validation errors')
-          .with.property('errors').to.eql([
+      expect(() => builder.assert(null)).toThrow((assert) => assert
+          .toBeError(ValidationError, /^Found 2 validation errors/)
+          .toHaveProperty('errors', expect.toMatchContents([
             { path: [], message: 'Hello, world!' },
             { path: [ 'myKey' ], message: 'Something else' },
-          ])
+          ])))
     })
 
     it('should properly wrap another ValidationError', () => {
@@ -96,31 +90,31 @@ describe('Errors', () => {
           .record(error1, 123)
           .record(error2, 456)
 
-      expect(() => builder.assert(null))
-          .to.throw(ValidationError, 'Found 4 validation errors')
-          .with.property('errors').to.eql([
+      expect(() => builder.assert(null)).toThrow((assert) => assert
+          .toBeError(ValidationError, /^Found 4 validation errors/)
+          .toHaveProperty('errors', expect.toMatchContents([
             { path: [], message: 'This has no path' },
             { path: [ 'myKey' ], message: 'A message' },
             { path: [ 123 ], message: 'This has no path' },
             { path: [ 456, 'myKey' ], message: 'A message' },
-          ])
+          ])))
     })
   })
 
   describe('Assertions', () => {
     it('should assert a schema error', () => {
-      expect(() => assertSchema(true, 'This should not throw')).to.not.throw()
+      expect(() => assertSchema(true, 'This should not throw')).not.toThrow()
       expect(() => assertSchema(false, 'This should throw'))
-          .to.throw(TypeError, 'This should throw')
+          .toThrowError(TypeError, 'This should throw')
     })
 
     it('should assert a validation error', () => {
-      expect(() => assertValidation(true, 'This should not throw')).to.not.throw()
+      expect(() => assertValidation(true, 'This should not throw')).not.toThrow()
       expect(() => assertValidation(false, 'This should throw'))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([ {
-            path: [], message: 'This should throw',
-          } ])
+          .toThrow((assert) => assert.toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([ {
+                path: [], message: 'This should throw',
+              } ])))
     })
   })
 })

--- a/test/02-validators.test.ts
+++ b/test/02-validators.test.ts
@@ -1,5 +1,3 @@
-import { expect } from 'chai'
-
 import { AbstractValidator, any, ConstantValidator, getValidator, ObjectValidator, TupleValidator } from '../src'
 
 import type { Schema } from '../src'
@@ -13,55 +11,54 @@ describe('Validators', () => {
 
   it('null', () => {
     expect(getValidator(null))
-        .to.be.instanceOf(ConstantValidator)
-        .with.property('constant').to.be.null
+        .toBeInstanceOf(ConstantValidator)
+        .toHaveProperty('constant', expect.toBeNull())
   })
 
   it('validators', () => {
-    expect(getValidator(any)).to.equal(any)
-    expect(getValidator(fakeValidator)).to.equal(fakeValidator)
+    expect(getValidator(any)).toStrictlyEqual(any)
+    expect(getValidator(fakeValidator)).toStrictlyEqual(fakeValidator)
   })
 
   it('primitives', () => {
     expect(getValidator(true))
-        .to.be.instanceOf(ConstantValidator)
-        .with.property('constant').to.be.true
+        .toBeInstanceOf(ConstantValidator)
+        .toHaveProperty('constant', expect.toBeTrue())
 
     expect(getValidator(12345))
-        .to.be.instanceOf(ConstantValidator)
-        .with.property('constant').to.equal(12345)
+        .toBeInstanceOf(ConstantValidator)
+        .toHaveProperty('constant', expect.toStrictlyEqual(12345))
 
     expect(getValidator('Hello, world!'))
-        .to.be.instanceOf(ConstantValidator)
-        .with.property('constant').to.equal('Hello, world!')
+        .toBeInstanceOf(ConstantValidator)
+        .toHaveProperty('constant', expect.toStrictlyEqual('Hello, world!'))
   })
 
   it('objects', () => {
     const objectValidator = getValidator({ foo: 'bar' })
     expect(objectValidator)
-        .to.be.instanceOf(ObjectValidator)
-        .with.property('schema').to.eql({ foo: 'bar' })
+        .toBeInstanceOf(ObjectValidator)
+        .toHaveProperty('schema', expect.toEqual({ foo: 'bar' }))
 
     expect(getValidator({ [Symbol.justusValidator]: objectValidator } as Schema))
-        .to.equal(objectValidator)
+        .toStrictlyEqual(objectValidator)
   })
 
   it('tuples', () => {
     expect(getValidator([ 1, 'foo' ]))
-        .to.be.instanceOf(TupleValidator)
-        .with.property('tuple').to.eql([ 1, 'foo' ])
+        .toBeInstanceOf(TupleValidator)
+        .toHaveProperty('tuple', expect.toEqual([ 1, 'foo' ]))
   })
 
   it('others (error)', () => {
     expect(() => getValidator(Symbol('foo') as any))
-        .to.throw(TypeError, 'Invalid validation (type=symbol)')
+        .toThrowError(TypeError, 'Invalid validation (type=symbol)')
   })
 
   it('validator iterator (tuple rest parameters)', () => {
     const array = [ ...fakeValidator ]
-    expect(array).to.have.length(1)
-    expect(array[0]).to.eql({
+    expect(array).toEqual([ {
       [Symbol.justusRestValidator]: fakeValidator,
-    })
+    } ])
   })
 })

--- a/test/10-primitives.test.ts
+++ b/test/10-primitives.test.ts
@@ -63,13 +63,25 @@ describe('Primitive validators', () => {
       expect(() => validate(constant('foo'), 'bar'))
           .to.throw(ValidationError, 'Found 1 validation error')
           .with.property('errors').to.eql([
-            { path: [], message: 'Value does not match constant "foo"' },
+            { path: [], message: 'Value does not match constant "foo" (string)' },
+          ])
+
+      expect(() => validate(constant(123n), 123))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'Value does not match constant "123" (bigint)' },
+          ])
+
+      expect(() => validate(constant(123), 123n))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'Value does not match constant "123" (number)' },
           ])
 
       expect(() => validate(constant(true), false))
           .to.throw(ValidationError, 'Found 1 validation error')
           .with.property('errors').to.eql([
-            { path: [], message: 'Value does not match constant "true"' },
+            { path: [], message: 'Value does not match constant "true" (boolean)' },
           ])
 
       expect(() => validate(constant(null), undefined))

--- a/test/10-primitives.test.ts
+++ b/test/10-primitives.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 
-import { any, boolean, constant, number, NumberValidator, string, StringValidator, validate, ValidationError } from '../src'
+import { any, bigint, BigIntValidator, boolean, constant, number, NumberValidator, string, StringValidator, validate, ValidationError } from '../src'
 
 describe('Primitive validators', () => {
   describe('any', () => {
@@ -320,6 +320,168 @@ describe('Primitive validators', () => {
     it('should support implicit branding', () => {
       const validator = string({ brand: 'foo' })
       expect(validate(validator, 'foo')).to.equal('foo')
+      expect(validator.brand).to.equal('foo')
+    })
+  })
+
+  describe('bigint', () => {
+    it('should validate a bigint', () => {
+      expect(validate(bigint, 0n)).to.equal(0n)
+      expect(validate(bigint, 123n)).to.equal(123n)
+
+      expect(validate(bigint, 0)).to.equal(0n)
+      expect(validate(bigint, 123)).to.equal(123n)
+
+      expect(() => validate(bigint, 123.456))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'BigInt can not be parsed from number' },
+          ])
+
+      expect(() => validate(bigint, '12345'))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'Value is not a "bigint"' },
+          ])
+    })
+
+    it('should validate a bigint within a range', () => {
+      const range = bigint({ minimum: -9, maximum: 19 })
+      expect(validate(range, 0)).to.equal(0n)
+      expect(validate(range, -9)).to.equal(-9n)
+      expect(validate(range, 19)).to.equal(19n)
+
+      expect(validate(bigint({ minimum: 0, maximum: 0 }), 0)).to.equal(0n)
+
+      expect(() => validate(range, -10))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'BigInt is less than -9' },
+          ])
+
+      expect(() => validate(range, 20))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'BigInt is greater than 19' },
+          ])
+
+      expect(() => bigint({ minimum: 10, maximum: 9 }))
+          .to.throw(TypeError, 'Constraint "minimum" (10) is greater than "maximum" (9)')
+    })
+
+    it('should validate a bigint within an exclusive range', () => {
+      const range1 = bigint({ exclusiveMinimum: 0, exclusiveMaximum: 10 })
+      expect(validate(range1, 1)).to.equal(1n)
+      expect(validate(range1, 9)).to.equal(9n)
+
+      expect(() => validate(range1, 0))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'BigInt is less than or equal to 0' },
+          ])
+
+      expect(() => validate(range1, 10))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'BigInt is greater than or equal to 10' },
+          ])
+
+      const range2 = bigint({ exclusiveMinimum: 0, maximum: 10 })
+      expect(validate(range2, 1)).to.equal(1n)
+      expect(validate(range2, 10)).to.equal(10n)
+
+      expect(() => validate(range2, 0))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'BigInt is less than or equal to 0' },
+          ])
+
+      expect(() => validate(range2, 11))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'BigInt is greater than 10' },
+          ])
+
+      const range3 = bigint({ minimum: 0, exclusiveMaximum: 10 })
+      expect(validate(range3, 0)).to.equal(0n)
+      expect(validate(range3, 9)).to.equal(9n)
+
+      expect(() => validate(range3, -1))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'BigInt is less than 0' },
+          ])
+
+      expect(() => validate(range3, 10))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'BigInt is greater than or equal to 10' },
+          ])
+
+      expect(() => bigint({ exclusiveMinimum: 2, exclusiveMaximum: 1 }))
+          .to.throw(TypeError, 'Constraint "exclusiveMaximum" (1) must be greater than "exclusiveMinimum" (2)')
+      expect(() => bigint({ exclusiveMinimum: 0, exclusiveMaximum: 0 }))
+          .to.throw(TypeError, 'Constraint "exclusiveMaximum" (0) must be greater than "exclusiveMinimum" (0)')
+
+      expect(() => bigint({ exclusiveMinimum: 2, maximum: 1 }))
+          .to.throw(TypeError, 'Constraint "maximum" (1) must be greater than "exclusiveMinimum" (2)')
+      expect(() => bigint({ exclusiveMinimum: 0, maximum: 0 }))
+          .to.throw(TypeError, 'Constraint "maximum" (0) must be greater than "exclusiveMinimum" (0)')
+
+      expect(() => bigint({ minimum: 2, exclusiveMaximum: 1 }))
+          .to.throw(TypeError, 'Constraint "exclusiveMaximum" (1) must be greater than "minimum" (2)')
+      expect(() => bigint({ minimum: 0, exclusiveMaximum: 0 }))
+          .to.throw(TypeError, 'Constraint "exclusiveMaximum" (0) must be greater than "minimum" (0)')
+    })
+
+    it('should validate multiple ofs', () => {
+      expect(validate(bigint({ multipleOf: 2 }), 4)).to.equal(4n)
+      expect(() => validate(bigint({ multipleOf: 2 }), 3))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'BigInt is not a multiple of 2' },
+          ])
+    })
+
+    it('should validate a bigint parsing a string', () => {
+      const validator = bigint({ fromString: true })
+      expect(validate(validator, '123456'), '123456').to.equal(123456n)
+      expect(validate(validator, '0xCAFE'), '0xCAFE').to.equal(0xCAFEn)
+      expect(validate(validator, '0o4321'), '0o4321').to.equal(0o4321n)
+      expect(validate(validator, '0b1011'), '0b1011').to.equal(0b1011n)
+      expect(() => validate(validator, '123.456'))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'BigInt can not be parsed from string' },
+          ])
+    })
+
+    it('should validate a bigint parsing a number', () => {
+      const validator = bigint({ fromNumber: true })
+      expect(validate(validator, 123456), '123456').to.equal(123456n)
+
+      expect(() => validate(validator, 123.456))
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'BigInt can not be parsed from number' },
+          ])
+
+      const validator2 = bigint({ fromNumber: false })
+      expect(() => validate(validator2, 123456), '123456')
+          .to.throw(ValidationError, 'Found 1 validation error')
+          .with.property('errors').to.eql([
+            { path: [], message: 'Value is not a "bigint"' },
+          ])
+    })
+
+    it('should validate a bigint using the BigIntValidator class', () => {
+      const validator = new BigIntValidator()
+      expect(validate(validator, 12345n)).to.equal(12345n)
+    })
+
+    it('should support implicit branding', () => {
+      const validator = bigint({ brand: 'foo' })
+      expect(validate(validator, 12345n)).to.equal(12345n)
       expect(validator.brand).to.equal('foo')
     })
   })

--- a/test/10-primitives.test.ts
+++ b/test/10-primitives.test.ts
@@ -1,504 +1,546 @@
-import { expect } from 'chai'
-
 import { any, bigint, BigIntValidator, boolean, constant, number, NumberValidator, string, StringValidator, validate, ValidationError } from '../src'
 
 describe('Primitive validators', () => {
   describe('any', () => {
     it('should validate anything', () => {
-      expect(validate(any, undefined)).to.be.undefined
-      expect(validate(any, 'foobar')).to.equal('foobar')
+      expect(validate(any, undefined)).toBeUndefined()
+      expect(validate(any, 'foobar')).toStrictlyEqual('foobar')
     })
   })
 
   describe('boolean', () => {
     it('should validate a boolean', () => {
-      expect(validate(boolean, true)).to.be.true
-      expect(validate(boolean, false)).to.be.false
+      expect(validate(boolean, true)).toBeTrue()
+      expect(validate(boolean, false)).toBeFalse()
     })
 
     it('should validate a boolean from a string', () => {
-      expect(validate(boolean({ fromString: true }), 'true')).to.be.true
-      expect(validate(boolean({ fromString: true }), 'TRUE')).to.be.true
-      expect(validate(boolean({ fromString: true }), 'false')).to.be.false
-      expect(validate(boolean({ fromString: true }), 'FALSE')).to.be.false
+      expect(validate(boolean({ fromString: true }), 'true')).toBeTrue()
+      expect(validate(boolean({ fromString: true }), 'TRUE')).toBeTrue()
+      expect(validate(boolean({ fromString: true }), 'false')).toBeFalse()
+      expect(validate(boolean({ fromString: true }), 'FALSE')).toBeFalse()
 
       expect(() => validate(boolean({ fromString: true }), 'hello'))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Boolean can not be parsed from string' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Boolean can not be parsed from string' },
+              ])),
+          )
     })
 
     it('should fail validating non booleans', () => {
       expect(() => validate(boolean, 'foobar'))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Value is not a "boolean"' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Value is not a "boolean"' },
+              ])))
 
       expect(() => validate(boolean, undefined))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Value is not a "boolean"' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Value is not a "boolean"' },
+              ])))
     })
   })
 
   describe('constants', () => {
     it('should validate a constant', () => {
-      expect(validate(constant(null), null)).to.be.null
-      expect(validate(constant(false), false)).to.be.false
-      expect(validate(constant('foo'), 'foo')).to.equal('foo')
-      expect(validate(constant(12345), 12345)).to.equal(12345)
-      expect(validate(constant(1234n), 1234n)).to.equal(1234n)
+      expect(validate(constant(null), null)).toBeNull()
+      expect(validate(constant(false), false)).toBeFalse()
+      expect(validate(constant('foo'), 'foo')).toStrictlyEqual('foo')
+      expect(validate(constant(12345), 12345)).toStrictlyEqual(12345)
+      expect(validate(constant(1234n), 1234n)).toStrictlyEqual(1234n)
 
-      expect(validate(null, null)).to.be.null
-      expect(validate(false as const, false)).to.be.false
-      expect(validate('foo' as const, 'foo')).to.equal('foo')
-      expect(validate(12345, 12345)).to.equal(12345)
-      expect(validate(1234n, 1234n)).to.equal(1234n)
+      expect(validate(null, null)).toBeNull()
+      expect(validate(false as const, false)).toBeFalse()
+      expect(validate('foo' as const, 'foo')).toStrictlyEqual('foo')
+      expect(validate(12345, 12345)).toStrictlyEqual(12345)
+      expect(validate(1234n, 1234n)).toStrictlyEqual(1234n)
     })
 
     it('should fail validating the wrong constant', () => {
       expect(() => validate(constant('foo'), 'bar'))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Value does not match constant "foo" (string)' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Value does not match constant "foo" (string)' },
+              ])))
 
       expect(() => validate(constant(123n), 123))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Value does not match constant "123" (bigint)' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Value does not match constant "123" (bigint)' },
+              ])))
 
       expect(() => validate(constant(123), 123n))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Value does not match constant "123" (number)' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Value does not match constant "123" (number)' },
+              ])))
 
       expect(() => validate(constant(true), false))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Value does not match constant "true" (boolean)' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Value does not match constant "true" (boolean)' },
+              ])))
 
       expect(() => validate(constant(null), undefined))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Value does not match constant "null"' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Value does not match constant "null"' },
+              ])))
     })
   })
 
   describe('number', () => {
     it('should validate a number', () => {
-      expect(validate(number, 0)).to.equal(0)
-      expect(validate(number, 123.456)).to.equal(123.456)
-      expect(validate(number, Number.NEGATIVE_INFINITY)).to.equal(Number.NEGATIVE_INFINITY)
-      expect(validate(number, Number.POSITIVE_INFINITY)).to.equal(Number.POSITIVE_INFINITY)
+      expect(validate(number, 0)).toStrictlyEqual(0)
+      expect(validate(number, 123.456)).toStrictlyEqual(123.456)
+      expect(validate(number, Number.NEGATIVE_INFINITY)).toStrictlyEqual(Number.NEGATIVE_INFINITY)
+      expect(validate(number, Number.POSITIVE_INFINITY)).toStrictlyEqual(Number.POSITIVE_INFINITY)
 
       expect(() => validate(number, 'foobar'))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Value is not a "number"' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Value is not a "number"' },
+              ])))
     })
 
     it('should validate a number within a range', () => {
       const range = number({ minimum: -9, maximum: 19 })
-      expect(validate(range, 0)).to.equal(0)
-      expect(validate(range, -9)).to.equal(-9)
-      expect(validate(range, 19)).to.equal(19)
+      expect(validate(range, 0)).toStrictlyEqual(0)
+      expect(validate(range, -9)).toStrictlyEqual(-9)
+      expect(validate(range, 19)).toStrictlyEqual(19)
 
-      expect(validate(number({ minimum: 0, maximum: 0 }), 0)).to.equal(0)
+      expect(validate(number({ minimum: 0, maximum: 0 }), 0)).toStrictlyEqual(0)
 
       expect(() => validate(range, -10))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number is less than -9' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number is less than -9' },
+              ])))
 
       expect(() => validate(range, 20))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number is greater than 19' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number is greater than 19' },
+              ])))
 
       expect(() => number({ minimum: 10, maximum: 9 }))
-          .to.throw(TypeError, 'Constraint "minimum" (10) is greater than "maximum" (9)')
+          .toThrowError(TypeError, 'Constraint "minimum" (10) is greater than "maximum" (9)')
     })
 
     it('should validate a number within an exclusive range', () => {
       const range1 = number({ exclusiveMinimum: 0, exclusiveMaximum: 1 })
-      expect(validate(range1, 0.001)).to.equal(0.001)
-      expect(validate(range1, 0.999)).to.equal(0.999)
+      expect(validate(range1, 0.001)).toStrictlyEqual(0.001)
+      expect(validate(range1, 0.999)).toStrictlyEqual(0.999)
 
       expect(() => validate(range1, 0))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number is less than or equal to 0' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number is less than or equal to 0' },
+              ])))
 
       expect(() => validate(range1, 1))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number is greater than or equal to 1' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number is greater than or equal to 1' },
+              ])))
 
       const range2 = number({ exclusiveMinimum: 0, maximum: 1 })
-      expect(validate(range2, 0.001)).to.equal(0.001)
-      expect(validate(range2, 1)).to.equal(1)
+      expect(validate(range2, 0.001)).toStrictlyEqual(0.001)
+      expect(validate(range2, 1)).toStrictlyEqual(1)
 
       expect(() => validate(range2, 0))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number is less than or equal to 0' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number is less than or equal to 0' },
+              ])))
 
       expect(() => validate(range2, 1.001))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number is greater than 1' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number is greater than 1' },
+              ])))
 
       const range3 = number({ minimum: 0, exclusiveMaximum: 1 })
-      expect(validate(range3, 0)).to.equal(0)
-      expect(validate(range3, 0.999)).to.equal(0.999)
+      expect(validate(range3, 0)).toStrictlyEqual(0)
+      expect(validate(range3, 0.999)).toStrictlyEqual(0.999)
 
       expect(() => validate(range3, -0.001))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number is less than 0' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number is less than 0' },
+              ])))
 
       expect(() => validate(range3, 1))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number is greater than or equal to 1' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number is greater than or equal to 1' },
+              ])))
 
       expect(() => number({ exclusiveMinimum: 2, exclusiveMaximum: 1 }))
-          .to.throw(TypeError, 'Constraint "exclusiveMaximum" (1) must be greater than "exclusiveMinimum" (2)')
+          .toThrowError(TypeError, 'Constraint "exclusiveMaximum" (1) must be greater than "exclusiveMinimum" (2)')
       expect(() => number({ exclusiveMinimum: 0, exclusiveMaximum: 0 }))
-          .to.throw(TypeError, 'Constraint "exclusiveMaximum" (0) must be greater than "exclusiveMinimum" (0)')
+          .toThrowError(TypeError, 'Constraint "exclusiveMaximum" (0) must be greater than "exclusiveMinimum" (0)')
 
       expect(() => number({ exclusiveMinimum: 2, maximum: 1 }))
-          .to.throw(TypeError, 'Constraint "maximum" (1) must be greater than "exclusiveMinimum" (2)')
+          .toThrowError(TypeError, 'Constraint "maximum" (1) must be greater than "exclusiveMinimum" (2)')
       expect(() => number({ exclusiveMinimum: 0, maximum: 0 }))
-          .to.throw(TypeError, 'Constraint "maximum" (0) must be greater than "exclusiveMinimum" (0)')
+          .toThrowError(TypeError, 'Constraint "maximum" (0) must be greater than "exclusiveMinimum" (0)')
 
       expect(() => number({ minimum: 2, exclusiveMaximum: 1 }))
-          .to.throw(TypeError, 'Constraint "exclusiveMaximum" (1) must be greater than "minimum" (2)')
+          .toThrowError(TypeError, 'Constraint "exclusiveMaximum" (1) must be greater than "minimum" (2)')
       expect(() => number({ minimum: 0, exclusiveMaximum: 0 }))
-          .to.throw(TypeError, 'Constraint "exclusiveMaximum" (0) must be greater than "minimum" (0)')
+          .toThrowError(TypeError, 'Constraint "exclusiveMaximum" (0) must be greater than "minimum" (0)')
     })
 
     it('should validate multiple ofs', () => {
       // integers
-      expect(validate(number({ multipleOf: 2 }), 4)).to.equal(4)
+      expect(validate(number({ multipleOf: 2 }), 4)).toStrictlyEqual(4)
       expect(() => validate(number({ multipleOf: 2 }), 3))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number is not a multiple of 2' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number is not a multiple of 2' },
+              ])))
 
       // reals
-      expect(validate(number({ multipleOf: 0.01 }), 0.12)).to.equal(0.12)
+      expect(validate(number({ multipleOf: 0.01 }), 0.12)).toStrictlyEqual(0.12)
       expect(() => validate(number({ multipleOf: 0.03 }), 0.07))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number is not a multiple of 0.03' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number is not a multiple of 0.03' },
+              ])))
 
-      expect(validate(number({ multipleOf: 0.000001 }), 0.123456)).to.equal(0.123456)
-      expect(validate(number({ multipleOf: 0.000001 }), 1000e100)).to.equal(1000e100)
+      expect(validate(number({ multipleOf: 0.000001 }), 0.123456)).toStrictlyEqual(0.123456)
+      expect(validate(number({ multipleOf: 0.000001 }), 1000e100)).toStrictlyEqual(1000e100)
 
       expect(() => validate(number({ multipleOf: 0.000001 }), 0.0000001))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number is not a multiple of 0.000001' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number is not a multiple of 0.000001' },
+              ])))
 
       // too much precision
-      expect(() => number({ multipleOf: 0.123456 })).to.not.throw()
+      expect(() => number({ multipleOf: 0.123456 })).not.toThrow()
       expect(() => number({ multipleOf: 0.1234567 }))
-          .to.throw(TypeError, 'Constraint "multipleOf" (0.1234567) requires too much precision')
+          .toThrowError(TypeError, 'Constraint "multipleOf" (0.1234567) requires too much precision')
 
       // this is a magical number that _multiplied_ by our precision (1 000 000)
       // result in an integer (100820000)... so we need a different way to check
       // for how many decimal digits a number has...
       expect(() => validate(number({ multipleOf: 0.000001 }), 100.82000000000001 ))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number is not a multiple of 0.000001' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number is not a multiple of 0.000001' },
+              ])))
 
       expect(() => validate(number({ multipleOf: 0.000001 }), Infinity ))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Can\'t calculate digits for number "Infinity"' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Can\'t calculate digits for number "Infinity"' },
+              ])))
     })
 
     it('should validate NaN', () => {
       expect(() => validate(number, NaN))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number is "NaN"' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number is "NaN"' },
+              ])))
       expect(() => validate(number({ allowNaN: false }), NaN))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number is "NaN"' },
-          ])
-      expect(validate(number({ allowNaN: true }), NaN)).to.be.NaN
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number is "NaN"' },
+              ])))
+      expect(validate(number({ allowNaN: true }), NaN)).toBeNaN()
     })
 
     it('should validate a number parsing a string', () => {
       const validator = number({ fromString: true })
-      expect(validate(validator, '123456'), '123456').to.equal(123456)
-      expect(validate(validator, '-12.34'), '-12.34').to.equal(-12.34)
-      expect(validate(validator, '0xCAFE'), '0xCAFE').to.equal(0xCAFE)
-      expect(validate(validator, '0o4321'), '0o4321').to.equal(0o4321)
-      expect(validate(validator, '0b1011'), '0b1011').to.equal(0b1011)
+      expect(validate(validator, '123456'), '123456').toStrictlyEqual(123456)
+      expect(validate(validator, '-12.34'), '-12.34').toStrictlyEqual(-12.34)
+      expect(validate(validator, '0xCAFE'), '0xCAFE').toStrictlyEqual(0xCAFE)
+      expect(validate(validator, '0o4321'), '0o4321').toStrictlyEqual(0o4321)
+      expect(validate(validator, '0b1011'), '0b1011').toStrictlyEqual(0b1011)
       expect(() => validate(validator, 'hello'))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Number can not be parsed from string' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Number can not be parsed from string' },
+              ])))
     })
 
     it('should validate a number using the NumberValidator class', () => {
       const validator = new NumberValidator()
-      expect(validate(validator, 12345)).to.equal(12345)
+      expect(validate(validator, 12345)).toStrictlyEqual(12345)
     })
 
     it('should support implicit branding', () => {
       const validator = number({ brand: 'foo' })
-      expect(validate(validator, 12345)).to.equal(12345)
-      expect(validator.brand).to.equal('foo')
+      expect(validate(validator, 12345)).toStrictlyEqual(12345)
+      expect(validator.brand).toStrictlyEqual('foo')
     })
   })
 
   describe('string', () => {
     it('should validate a string', () => {
-      expect(validate(string, 'foobar')).to.equal('foobar')
-      expect(validate(string, '')).to.equal('')
+      expect(validate(string, 'foobar')).toStrictlyEqual('foobar')
+      expect(validate(string, '')).toStrictlyEqual('')
 
       expect(() => validate(string, 123))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Value is not a "string"' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Value is not a "string"' },
+              ])))
     })
 
     it('should validate a string of a specified length', () => {
       const length = string({ minLength: 3, maxLength: 6 })
-      expect(validate(length, 'foo')).to.equal('foo')
-      expect(validate(length, 'foobar')).to.equal('foobar')
+      expect(validate(length, 'foo')).toStrictlyEqual('foo')
+      expect(validate(length, 'foobar')).toStrictlyEqual('foobar')
       expect(() => validate(length, 'fo'))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'String must have a minimum length of 3' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'String must have a minimum length of 3' },
+              ])))
       expect(() => validate(length, 'foobarx'))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'String must have a maximum length of 6' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'String must have a maximum length of 6' },
+              ])))
 
-      expect(validate(string({ minLength: 3, maxLength: 3 }), 'foo')).to.equal('foo')
+      expect(validate(string({ minLength: 3, maxLength: 3 }), 'foo')).toStrictlyEqual('foo')
 
       expect(() => string({ minLength: -1 }))
-          .to.throw(TypeError, 'Constraint "minLength" (-1) must be non-negative')
+          .toThrowError(TypeError, 'Constraint "minLength" (-1) must be non-negative')
       expect(() => string({ maxLength: -1 }))
-          .to.throw(TypeError, 'Constraint "maxLength" (-1) must be non-negative')
+          .toThrowError(TypeError, 'Constraint "maxLength" (-1) must be non-negative')
       expect(() => string({ minLength: 4, maxLength: 3 }))
-          .to.throw(TypeError, 'Constraint "minLength" (4) is greater than "maxLength" (3)')
+          .toThrowError(TypeError, 'Constraint "minLength" (4) is greater than "maxLength" (3)')
     })
 
     it('should validate a string a with a pattern', () => {
-      expect(validate(string({ pattern: /^foobar$/ }), 'foobar')).to.equal('foobar')
+      expect(validate(string({ pattern: /^foobar$/ }), 'foobar')).toStrictlyEqual('foobar')
       expect(() => validate(string({ pattern: /^$/ }), 'foobar'))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'String does not match required pattern /^$/' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'String does not match required pattern /^$/' },
+              ])))
     })
 
     it('should validate a string using the StringValidator class', () => {
       const validator = new StringValidator()
-      expect(validate(validator, 'foo')).to.equal('foo')
+      expect(validate(validator, 'foo')).toStrictlyEqual('foo')
     })
 
     it('should support implicit branding', () => {
       const validator = string({ brand: 'foo' })
-      expect(validate(validator, 'foo')).to.equal('foo')
-      expect(validator.brand).to.equal('foo')
+      expect(validate(validator, 'foo')).toStrictlyEqual('foo')
+      expect(validator.brand).toStrictlyEqual('foo')
     })
   })
 
   describe('bigint', () => {
     it('should validate a bigint', () => {
-      expect(validate(bigint, 0n)).to.equal(0n)
-      expect(validate(bigint, 123n)).to.equal(123n)
+      expect(validate(bigint, 0n)).toStrictlyEqual(0n)
+      expect(validate(bigint, 123n)).toStrictlyEqual(123n)
 
-      expect(validate(bigint, 0)).to.equal(0n)
-      expect(validate(bigint, 123)).to.equal(123n)
+      expect(validate(bigint, 0)).toStrictlyEqual(0n)
+      expect(validate(bigint, 123)).toStrictlyEqual(123n)
 
       expect(() => validate(bigint, 123.456))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'BigInt can not be parsed from number' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'BigInt can not be parsed from number' },
+              ])))
 
       expect(() => validate(bigint, '12345'))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Value is not a "bigint"' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Value is not a "bigint"' },
+              ])))
     })
 
     it('should validate a bigint within a range', () => {
       const range = bigint({ minimum: -9, maximum: 19 })
-      expect(validate(range, 0)).to.equal(0n)
-      expect(validate(range, -9)).to.equal(-9n)
-      expect(validate(range, 19)).to.equal(19n)
+      expect(validate(range, 0)).toStrictlyEqual(0n)
+      expect(validate(range, -9)).toStrictlyEqual(-9n)
+      expect(validate(range, 19)).toStrictlyEqual(19n)
 
-      expect(validate(bigint({ minimum: 0, maximum: 0 }), 0)).to.equal(0n)
+      expect(validate(bigint({ minimum: 0, maximum: 0 }), 0)).toStrictlyEqual(0n)
 
       expect(() => validate(range, -10))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'BigInt is less than -9' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'BigInt is less than -9' },
+              ])))
 
       expect(() => validate(range, 20))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'BigInt is greater than 19' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'BigInt is greater than 19' },
+              ])))
 
       expect(() => bigint({ minimum: 10, maximum: 9 }))
-          .to.throw(TypeError, 'Constraint "minimum" (10) is greater than "maximum" (9)')
+          .toThrowError(TypeError, 'Constraint "minimum" (10) is greater than "maximum" (9)')
     })
 
     it('should validate a bigint within an exclusive range', () => {
       const range1 = bigint({ exclusiveMinimum: 0, exclusiveMaximum: 10 })
-      expect(validate(range1, 1)).to.equal(1n)
-      expect(validate(range1, 9)).to.equal(9n)
+      expect(validate(range1, 1)).toStrictlyEqual(1n)
+      expect(validate(range1, 9)).toStrictlyEqual(9n)
 
       expect(() => validate(range1, 0))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'BigInt is less than or equal to 0' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'BigInt is less than or equal to 0' },
+              ])))
 
       expect(() => validate(range1, 10))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'BigInt is greater than or equal to 10' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'BigInt is greater than or equal to 10' },
+              ])))
 
       const range2 = bigint({ exclusiveMinimum: 0, maximum: 10 })
-      expect(validate(range2, 1)).to.equal(1n)
-      expect(validate(range2, 10)).to.equal(10n)
+      expect(validate(range2, 1)).toStrictlyEqual(1n)
+      expect(validate(range2, 10)).toStrictlyEqual(10n)
 
       expect(() => validate(range2, 0))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'BigInt is less than or equal to 0' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'BigInt is less than or equal to 0' },
+              ])))
 
       expect(() => validate(range2, 11))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'BigInt is greater than 10' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'BigInt is greater than 10' },
+              ])))
 
       const range3 = bigint({ minimum: 0, exclusiveMaximum: 10 })
-      expect(validate(range3, 0)).to.equal(0n)
-      expect(validate(range3, 9)).to.equal(9n)
+      expect(validate(range3, 0)).toStrictlyEqual(0n)
+      expect(validate(range3, 9)).toStrictlyEqual(9n)
 
       expect(() => validate(range3, -1))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'BigInt is less than 0' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'BigInt is less than 0' },
+              ])))
 
       expect(() => validate(range3, 10))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'BigInt is greater than or equal to 10' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'BigInt is greater than or equal to 10' },
+              ])))
 
       expect(() => bigint({ exclusiveMinimum: 2, exclusiveMaximum: 1 }))
-          .to.throw(TypeError, 'Constraint "exclusiveMaximum" (1) must be greater than "exclusiveMinimum" (2)')
+          .toThrowError(TypeError, 'Constraint "exclusiveMaximum" (1) must be greater than "exclusiveMinimum" (2)')
       expect(() => bigint({ exclusiveMinimum: 0, exclusiveMaximum: 0 }))
-          .to.throw(TypeError, 'Constraint "exclusiveMaximum" (0) must be greater than "exclusiveMinimum" (0)')
+          .toThrowError(TypeError, 'Constraint "exclusiveMaximum" (0) must be greater than "exclusiveMinimum" (0)')
 
       expect(() => bigint({ exclusiveMinimum: 2, maximum: 1 }))
-          .to.throw(TypeError, 'Constraint "maximum" (1) must be greater than "exclusiveMinimum" (2)')
+          .toThrowError(TypeError, 'Constraint "maximum" (1) must be greater than "exclusiveMinimum" (2)')
       expect(() => bigint({ exclusiveMinimum: 0, maximum: 0 }))
-          .to.throw(TypeError, 'Constraint "maximum" (0) must be greater than "exclusiveMinimum" (0)')
+          .toThrowError(TypeError, 'Constraint "maximum" (0) must be greater than "exclusiveMinimum" (0)')
 
       expect(() => bigint({ minimum: 2, exclusiveMaximum: 1 }))
-          .to.throw(TypeError, 'Constraint "exclusiveMaximum" (1) must be greater than "minimum" (2)')
+          .toThrowError(TypeError, 'Constraint "exclusiveMaximum" (1) must be greater than "minimum" (2)')
       expect(() => bigint({ minimum: 0, exclusiveMaximum: 0 }))
-          .to.throw(TypeError, 'Constraint "exclusiveMaximum" (0) must be greater than "minimum" (0)')
+          .toThrowError(TypeError, 'Constraint "exclusiveMaximum" (0) must be greater than "minimum" (0)')
     })
 
     it('should validate multiple ofs', () => {
-      expect(validate(bigint({ multipleOf: 2 }), 4)).to.equal(4n)
+      expect(validate(bigint({ multipleOf: 2 }), 4)).toStrictlyEqual(4n)
       expect(() => validate(bigint({ multipleOf: 2 }), 3))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'BigInt is not a multiple of 2' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'BigInt is not a multiple of 2' },
+              ])))
     })
 
     it('should validate a bigint parsing a string', () => {
       const validator = bigint({ fromString: true })
-      expect(validate(validator, '123456'), '123456').to.equal(123456n)
-      expect(validate(validator, '0xCAFE'), '0xCAFE').to.equal(0xCAFEn)
-      expect(validate(validator, '0o4321'), '0o4321').to.equal(0o4321n)
-      expect(validate(validator, '0b1011'), '0b1011').to.equal(0b1011n)
+      expect(validate(validator, '123456'), '123456').toStrictlyEqual(123456n)
+      expect(validate(validator, '0xCAFE'), '0xCAFE').toStrictlyEqual(0xCAFEn)
+      expect(validate(validator, '0o4321'), '0o4321').toStrictlyEqual(0o4321n)
+      expect(validate(validator, '0b1011'), '0b1011').toStrictlyEqual(0b1011n)
       expect(() => validate(validator, '123.456'))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'BigInt can not be parsed from string' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'BigInt can not be parsed from string' },
+              ])))
     })
 
     it('should validate a bigint parsing a number', () => {
       const validator = bigint({ fromNumber: true })
-      expect(validate(validator, 123456), '123456').to.equal(123456n)
+      expect(validate(validator, 123456), '123456').toStrictlyEqual(123456n)
 
       expect(() => validate(validator, 123.456))
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'BigInt can not be parsed from number' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'BigInt can not be parsed from number' },
+              ])))
 
       const validator2 = bigint({ fromNumber: false })
       expect(() => validate(validator2, 123456), '123456')
-          .to.throw(ValidationError, 'Found 1 validation error')
-          .with.property('errors').to.eql([
-            { path: [], message: 'Value is not a "bigint"' },
-          ])
+          .toThrow((assert) => assert
+              .toBeError(ValidationError, /^Found 1 validation error/)
+              .toHaveProperty('errors', expect.toMatchContents([
+                { path: [], message: 'Value is not a "bigint"' },
+              ])))
     })
 
     it('should validate a bigint using the BigIntValidator class', () => {
       const validator = new BigIntValidator()
-      expect(validate(validator, 12345n)).to.equal(12345n)
+      expect(validate(validator, 12345n)).toStrictlyEqual(12345n)
     })
 
     it('should support implicit branding', () => {
       const validator = bigint({ brand: 'foo' })
-      expect(validate(validator, 12345n)).to.equal(12345n)
-      expect(validator.brand).to.equal('foo')
+      expect(validate(validator, 12345n)).toStrictlyEqual(12345n)
+      expect(validator.brand).toStrictlyEqual('foo')
     })
   })
 })

--- a/test/10-primitives.test.ts
+++ b/test/10-primitives.test.ts
@@ -49,10 +49,14 @@ describe('Primitive validators', () => {
       expect(validate(constant(null), null)).to.be.null
       expect(validate(constant(false), false)).to.be.false
       expect(validate(constant('foo'), 'foo')).to.equal('foo')
+      expect(validate(constant(12345), 12345)).to.equal(12345)
+      expect(validate(constant(1234n), 1234n)).to.equal(1234n)
 
       expect(validate(null, null)).to.be.null
       expect(validate(false as const, false)).to.be.false
       expect(validate('foo' as const, 'foo')).to.equal('foo')
+      expect(validate(12345, 12345)).to.equal(12345)
+      expect(validate(1234n, 1234n)).to.equal(1234n)
     })
 
     it('should fail validating the wrong constant', () => {

--- a/test/11-arrays.test.ts
+++ b/test/11-arrays.test.ts
@@ -75,9 +75,9 @@ describe('Array validator', () => {
     expect(() => validate(arrayOf('a'), [ 'a', true, 'b', 123 ]))
         .to.throw(ValidationError, 'Found 3 validation errors')
         .with.property('errors').to.eql([
-          { path: [ 1 ], message: 'Value does not match constant "a"' },
-          { path: [ 2 ], message: 'Value does not match constant "a"' },
-          { path: [ 3 ], message: 'Value does not match constant "a"' },
+          { path: [ 1 ], message: 'Value does not match constant "a" (string)' },
+          { path: [ 2 ], message: 'Value does not match constant "a" (string)' },
+          { path: [ 3 ], message: 'Value does not match constant "a" (string)' },
         ])
 
     expect(validate(arrayOf('a'), [ 'a', 'a', 'a' ])).to.eql([ 'a', 'a', 'a' ])
@@ -85,9 +85,9 @@ describe('Array validator', () => {
     expect(() => validate(array({ items: 'a', uniqueItems: true }), [ 'a', true, 'a', 123 ]))
         .to.throw(ValidationError, 'Found 3 validation errors')
         .with.property('errors').to.eql([
-          { path: [ 1 ], message: 'Value does not match constant "a"' },
+          { path: [ 1 ], message: 'Value does not match constant "a" (string)' },
           { path: [ 2 ], message: 'Duplicate of item at index 0' },
-          { path: [ 3 ], message: 'Value does not match constant "a"' },
+          { path: [ 3 ], message: 'Value does not match constant "a" (string)' },
         ])
   })
 

--- a/test/11-arrays.test.ts
+++ b/test/11-arrays.test.ts
@@ -1,98 +1,104 @@
-import { expect } from 'chai'
-
 import { array, arrayOf, ArrayValidator, string, validate, ValidationError } from '../src'
 
 describe('Array validator', () => {
   it('should validate an array', () => {
-    expect(validate(array, [ 1, true, 'foo' ])).to.eql([ 1, true, 'foo' ])
-    expect(validate(array, [])).to.eql([])
+    expect(validate(array, [ 1, true, 'foo' ])).toEqual([ 1, true, 'foo' ])
+    expect(validate(array, [])).toEqual([])
 
     expect(() => validate(array, 123))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [], message: 'Value is not an "array"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [], message: 'Value is not an "array"' },
+            ])))
   })
 
   it('should validate an array of a specified length', () => {
     const length = array({ minItems: 3, maxItems: 6 })
-    expect(validate(length, [ 1, 2, 3 ])).to.eql([ 1, 2, 3 ])
-    expect(validate(length, [ 1, 2, 3, 4, 5, 6 ])).to.eql([ 1, 2, 3, 4, 5, 6 ])
+    expect(validate(length, [ 1, 2, 3 ])).toEqual([ 1, 2, 3 ])
+    expect(validate(length, [ 1, 2, 3, 4, 5, 6 ])).toEqual([ 1, 2, 3, 4, 5, 6 ])
     expect(() => validate(length, [ 1, 2 ]))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [], message: 'Array must have a minimum length of 3' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [], message: 'Array must have a minimum length of 3' },
+            ])))
     expect(() => validate(length, [ 1, 2, 3, 4, 5, 6, 7 ]))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [], message: 'Array must have a maximum length of 6' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [], message: 'Array must have a maximum length of 6' },
+            ])))
 
-    expect(validate(array({ minItems: 3, maxItems: 3 }), [ 1, 2, 3 ])).to.eql([ 1, 2, 3 ])
+    expect(validate(array({ minItems: 3, maxItems: 3 }), [ 1, 2, 3 ])).toEqual([ 1, 2, 3 ])
 
     expect(() => array({ minItems: -1 }))
-        .to.throw(TypeError, 'Constraint "minItems" (-1) must be non-negative')
+        .toThrowError(TypeError, 'Constraint "minItems" (-1) must be non-negative')
     expect(() => array({ maxItems: -1 }))
-        .to.throw(TypeError, 'Constraint "maxItems" (-1) must be non-negative')
+        .toThrowError(TypeError, 'Constraint "maxItems" (-1) must be non-negative')
     expect(() => array({ minItems: 4, maxItems: 3 }))
-        .to.throw(TypeError, 'Constraint "minItems" (4) is greater than "maxItems" (3)')
+        .toThrowError(TypeError, 'Constraint "minItems" (4) is greater than "maxItems" (3)')
   })
 
   it('should validate an array with unique items', () => {
-    expect(validate(array, [ 1, 2, 1 ])).to.eql([ 1, 2, 1 ])
-    expect(validate(array({ uniqueItems: false }), [ 1, 2, 1 ])).to.eql([ 1, 2, 1 ])
+    expect(validate(array, [ 1, 2, 1 ])).toEqual([ 1, 2, 1 ])
+    expect(validate(array({ uniqueItems: false }), [ 1, 2, 1 ])).toEqual([ 1, 2, 1 ])
 
     expect(() => validate(array({ uniqueItems: true }), [ 1, 2, 1, 2 ]))
-        .to.throw(ValidationError, 'Found 2 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 2 ], message: 'Duplicate of item at index 0' },
-          { path: [ 3 ], message: 'Duplicate of item at index 1' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 2 ], message: 'Duplicate of item at index 0' },
+              { path: [ 3 ], message: 'Duplicate of item at index 1' },
+            ])))
   })
 
   it('should validate an array with items of a specific type', () => {
-    expect(validate(arrayOf(string), [ 'a', 'b', 'c' ])).to.eql([ 'a', 'b', 'c' ])
+    expect(validate(arrayOf(string), [ 'a', 'b', 'c' ])).toEqual([ 'a', 'b', 'c' ])
 
     expect(() => validate(arrayOf(string), [ 'a', true, 'b', 123 ]))
-        .to.throw(ValidationError, 'Found 2 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 1 ], message: 'Value is not a "string"' },
-          { path: [ 3 ], message: 'Value is not a "string"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 1 ], message: 'Value is not a "string"' },
+              { path: [ 3 ], message: 'Value is not a "string"' },
+            ])))
 
-    expect(validate(arrayOf(string), [ 'a', 'b', 'c' ])).to.eql([ 'a', 'b', 'c' ])
+    expect(validate(arrayOf(string), [ 'a', 'b', 'c' ])).toEqual([ 'a', 'b', 'c' ])
 
     expect(() => validate(arrayOf(string), [ 'a', true, 'b', 123 ]))
-        .to.throw(ValidationError, 'Found 2 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 1 ], message: 'Value is not a "string"' },
-          { path: [ 3 ], message: 'Value is not a "string"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 1 ], message: 'Value is not a "string"' },
+              { path: [ 3 ], message: 'Value is not a "string"' },
+            ])))
 
-    expect(validate(arrayOf('a'), [ 'a', 'a', 'a' ])).to.eql([ 'a', 'a', 'a' ])
+    expect(validate(arrayOf('a'), [ 'a', 'a', 'a' ])).toEqual([ 'a', 'a', 'a' ])
 
     expect(() => validate(arrayOf('a'), [ 'a', true, 'b', 123 ]))
-        .to.throw(ValidationError, 'Found 3 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 1 ], message: 'Value does not match constant "a" (string)' },
-          { path: [ 2 ], message: 'Value does not match constant "a" (string)' },
-          { path: [ 3 ], message: 'Value does not match constant "a" (string)' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 3 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 1 ], message: 'Value does not match constant "a" (string)' },
+              { path: [ 2 ], message: 'Value does not match constant "a" (string)' },
+              { path: [ 3 ], message: 'Value does not match constant "a" (string)' },
+            ])))
 
-    expect(validate(arrayOf('a'), [ 'a', 'a', 'a' ])).to.eql([ 'a', 'a', 'a' ])
+    expect(validate(arrayOf('a'), [ 'a', 'a', 'a' ])).toEqual([ 'a', 'a', 'a' ])
 
     expect(() => validate(array({ items: 'a', uniqueItems: true }), [ 'a', true, 'a', 123 ]))
-        .to.throw(ValidationError, 'Found 3 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 1 ], message: 'Value does not match constant "a" (string)' },
-          { path: [ 2 ], message: 'Duplicate of item at index 0' },
-          { path: [ 3 ], message: 'Value does not match constant "a" (string)' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 3 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 1 ], message: 'Value does not match constant "a" (string)' },
+              { path: [ 2 ], message: 'Duplicate of item at index 0' },
+              { path: [ 3 ], message: 'Value does not match constant "a" (string)' },
+            ])))
   })
 
   it('should validate an array using the ArrayValidator class', () => {
     const validator = new ArrayValidator()
-    expect(validate(validator, [ 1, 'foo', true ])).to.eql([ 1, 'foo', true ])
+    expect(validate(validator, [ 1, 'foo', true ])).toEqual([ 1, 'foo', true ])
   })
 })

--- a/test/12-objects.test.ts
+++ b/test/12-objects.test.ts
@@ -1,56 +1,60 @@
-import { expect } from 'chai'
-
 import { allowAdditionalProperties, any, array, boolean, never, number, object, objectOf, optional, partial, string, strip, validate, ValidationError } from '../src'
 
 describe('Object validator', () => {
   it('should validate a generic object', () => {
-    expect(validate(object, {})).to.eql({})
-    expect(validate(object, { a: 1, b: 'foo' })).to.eql({ a: 1, b: 'foo' })
+    expect(validate(object, {})).toEqual({})
+    expect(validate(object, { a: 1, b: 'foo' })).toEqual({ a: 1, b: 'foo' })
 
     expect(() => validate(object, 123))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [], message: 'Value is not an "object"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [], message: 'Value is not an "object"' },
+            ])))
 
     expect(() => validate(object, null))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [], message: 'Value is "null"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [], message: 'Value is "null"' },
+            ])))
   })
 
   it('should validate an object', () => {
     const validator = object({ a: number, b: string })
 
-    expect(validate(validator, { a: 1, b: 'foo' })).to.eql({ a: 1, b: 'foo' })
+    expect(validate(validator, { a: 1, b: 'foo' })).toEqual({ a: 1, b: 'foo' })
 
     expect(() => validate(validator, 123))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [], message: 'Value is not an "object"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [], message: 'Value is not an "object"' },
+            ])))
 
     expect(() => validate(validator, null))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [], message: 'Value is "null"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [], message: 'Value is "null"' },
+            ])))
 
     expect(() => validate(validator, {}))
-        .to.throw(ValidationError, 'Found 2 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 'a' ], message: 'Required property missing' },
-          { path: [ 'b' ], message: 'Required property missing' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'a' ], message: 'Required property missing' },
+              { path: [ 'b' ], message: 'Required property missing' },
+            ])))
 
     expect(() => validate(validator, { a: 'foo', b: 1, c: true }))
-        .to.throw(ValidationError, 'Found 3 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 'a' ], message: 'Value is not a "number"' },
-          { path: [ 'b' ], message: 'Value is not a "string"' },
-          { path: [ 'c' ], message: 'Unknown property' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 3 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'a' ], message: 'Value is not a "number"' },
+              { path: [ 'b' ], message: 'Value is not a "string"' },
+              { path: [ 'c' ], message: 'Unknown property' },
+            ])))
   })
 
   it('should validate a complex object', () => {
@@ -80,7 +84,7 @@ describe('Object validator', () => {
         description: 'bar',
         value: 654.321,
       } ],
-    })).to.eql({
+    })).toEqual({
       version: 1,
       title: 'hello, world!',
       contents: [ {
@@ -93,22 +97,24 @@ describe('Object validator', () => {
     })
 
     expect(() => validate(validator, { version: 2, contents: [] }))
-        .to.throw(ValidationError, 'Found 3 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 'version' ], message: 'Value does not match constant "1" (number)' },
-          { path: [ 'title' ], message: 'Required property missing' },
-          { path: [ 'contents' ], message: 'Array must have a minimum length of 2' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 3 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'version' ], message: 'Value does not match constant "1" (number)' },
+              { path: [ 'title' ], message: 'Required property missing' },
+              { path: [ 'contents' ], message: 'Array must have a minimum length of 2' },
+            ])))
 
     expect(() => validate(validator, { version: 3, contents: [ {}, 'foo' ] }))
-        .to.throw(ValidationError, 'Found 5 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 'version' ], message: 'Value does not match constant "1" (number)' },
-          { path: [ 'title' ], message: 'Required property missing' },
-          { path: [ 'contents', 0, 'description' ], message: 'Required property missing' },
-          { path: [ 'contents', 0, 'value' ], message: 'Required property missing' },
-          { path: [ 'contents', 1 ], message: 'Value is not an "object"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 5 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'version' ], message: 'Value does not match constant "1" (number)' },
+              { path: [ 'title' ], message: 'Required property missing' },
+              { path: [ 'contents', 0, 'description' ], message: 'Required property missing' },
+              { path: [ 'contents', 0, 'value' ], message: 'Required property missing' },
+              { path: [ 'contents', 1 ], message: 'Value is not an "object"' },
+            ])))
   })
 
   it('should validate an object tree', () => {
@@ -119,86 +125,93 @@ describe('Object validator', () => {
     validate(object3, { two: { one: { zero: 'zero' } } })
 
     expect(() => validate(object3, { two: { one: { zero: 0 } } } ))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [ 'two', 'one', 'zero' ], message: 'Value is not a "string"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'two', 'one', 'zero' ], message: 'Value is not a "string"' },
+            ])))
   })
 
   it('should validate an object with additional properties', () => {
     const validator1 = object({ foo: true, ...allowAdditionalProperties, baz: never })
     expect(validate(validator1, { foo: true, bar: 'whatever' }))
-        .to.eql({ foo: true, bar: 'whatever' })
+        .toEqual({ foo: true, bar: 'whatever' })
     expect(() => validate(validator1, { foo: false, bar: 'whatever', baz: true }))
-        .to.throw(ValidationError, 'Found 2 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 'foo' ], message: 'Value does not match constant "true" (boolean)' },
-          { path: [ 'baz' ], message: 'Forbidden property' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'foo' ], message: 'Value does not match constant "true" (boolean)' },
+              { path: [ 'baz' ], message: 'Forbidden property' },
+            ])))
 
     const validator2 = object({ foo: true, ...allowAdditionalProperties(true), baz: never })
     expect(validate(validator2, { foo: true, bar: 'whatever' }))
-        .to.eql({ foo: true, bar: 'whatever' })
+        .toEqual({ foo: true, bar: 'whatever' })
     expect(() => validate(validator2, { foo: false, bar: 'whatever', baz: true }))
-        .to.throw(ValidationError, 'Found 2 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 'foo' ], message: 'Value does not match constant "true" (boolean)' },
-          { path: [ 'baz' ], message: 'Forbidden property' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'foo' ], message: 'Value does not match constant "true" (boolean)' },
+              { path: [ 'baz' ], message: 'Forbidden property' },
+            ])))
 
     const validator3 = object({ foo: true, ...allowAdditionalProperties(any), baz: never })
     expect(validate(validator3, { foo: true, bar: 'whatever' }))
-        .to.eql({ foo: true, bar: 'whatever' })
+        .toEqual({ foo: true, bar: 'whatever' })
     expect(() => validate(validator3, { foo: false, bar: 'whatever', baz: true }))
-        .to.throw(ValidationError, 'Found 2 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 'foo' ], message: 'Value does not match constant "true" (boolean)' },
-          { path: [ 'baz' ], message: 'Forbidden property' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'foo' ], message: 'Value does not match constant "true" (boolean)' },
+              { path: [ 'baz' ], message: 'Forbidden property' },
+            ])))
 
     const validator4 = object({ foo: true, ...allowAdditionalProperties(false), baz: never })
     expect(() => validate(validator4, { foo: true, bar: 'whatever', baz: true }))
-        .to.throw(ValidationError, 'Found 2 validation error')
-        .with.property('errors').to.eql([
-          { path: [ 'baz' ], message: 'Forbidden property' },
-          { path: [ 'bar' ], message: 'Unknown property' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'baz' ], message: 'Forbidden property' },
+              { path: [ 'bar' ], message: 'Unknown property' },
+            ])))
 
     const validator5 = object({ foo: true, ...allowAdditionalProperties(string), baz: never })
     expect(validate(validator5, { foo: true, bar: 'whatever' }))
-        .to.eql({ foo: true, bar: 'whatever' })
+        .toEqual({ foo: true, bar: 'whatever' })
     expect(validate(validator5, { foo: true, bar: undefined, baz: undefined }))
-        .to.eql({ foo: true })
-        .to.have.keys([ 'foo' ]) // remove undefined props
+        .toEqual({ foo: true })
     expect(() => validate(validator5, { foo: true, bar: 123, baz: true }))
-        .to.throw(ValidationError, 'Found 2 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 'baz' ], message: 'Forbidden property' },
-          { path: [ 'bar' ], message: 'Value is not a "string"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'baz' ], message: 'Forbidden property' },
+              { path: [ 'bar' ], message: 'Value is not a "string"' },
+            ])))
   })
 
   it('should validate an object of specific values', () => {
     const validator1 = objectOf(string)
     expect(validate(validator1, { foo: 'FOO', bar: 'BAR' }))
-        .to.eql({ foo: 'FOO', bar: 'BAR' })
+        .toEqual({ foo: 'FOO', bar: 'BAR' })
 
     expect(() => validate(validator1, { foo: 'FOO', bar: true }))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [ 'bar' ], message: 'Value is not a "string"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'bar' ], message: 'Value is not a "string"' },
+            ])))
 
     const validator2 = objectOf({ test: boolean })
     expect(validate(validator2, { foo: { test: true }, bar: { test: false } }))
-        .to.eql({ foo: { test: true }, bar: { test: false } })
+        .toEqual({ foo: { test: true }, bar: { test: false } })
 
     expect(() => validate(validator2, { foo: { test: 'hello' }, bar: { test: 123 } }))
-        .to.throw(ValidationError, 'Found 2 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 'foo', 'test' ], message: 'Value is not a "boolean"' },
-          { path: [ 'bar', 'test' ], message: 'Value is not a "boolean"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'foo', 'test' ], message: 'Value is not a "boolean"' },
+              { path: [ 'bar', 'test' ], message: 'Value is not a "boolean"' },
+            ])))
   })
 
   it('should strip additional or forbidden properties when asked to do so', () => {
@@ -206,79 +219,71 @@ describe('Object validator', () => {
 
     // normal validation
     expect(validate(validator, { foo: true }))
-        .to.eql({ foo: true })
+        .toEqual({ foo: true })
 
     // validate with forbidden/unknown properties are "undefined"
     expect(validate(validator, { foo: true, bar: undefined, baz: undefined }))
-        .to.eql({ foo: true })
-        .to.have.keys([ 'foo' ])
+        .toEqual({ foo: true })
 
     // validate with forbidden/unknown properties set
     expect(() => validate(validator, { foo: true, bar: 'whatever', baz: 123 }))
-        .to.throw(ValidationError, 'Found 2 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 'baz' ], message: 'Forbidden property' },
-          { path: [ 'bar' ], message: 'Unknown property' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'baz' ], message: 'Forbidden property' },
+              { path: [ 'bar' ], message: 'Unknown property' },
+            ])))
 
     expect(() => strip(validator, { foo: true, bar: 'whatever', baz: 123 }, {
       stripAdditionalProperties: false,
     }))
-        .to.throw(ValidationError, 'Found 2 validation errors')
-        .with.property('errors').to.eql([
-          { path: [ 'baz' ], message: 'Forbidden property' },
-          { path: [ 'bar' ], message: 'Unknown property' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'baz' ], message: 'Forbidden property' },
+              { path: [ 'bar' ], message: 'Unknown property' },
+            ])))
 
     // strip with unknown properties set
     expect(validate(validator, { foo: true, bar: 'whatever' }, {
       stripAdditionalProperties: true,
-    }))
-        .to.eql({ foo: true })
-        .to.have.keys([ 'foo' ])
+    })).toEqual({ foo: true })
 
     expect(strip(validator, { foo: true, bar: 'whatever' }))
-        .to.eql({ foo: true })
-        .to.have.keys([ 'foo' ])
+        .toEqual({ foo: true })
 
     // strip with forbidden properties set
     expect(validate(validator, { foo: true, baz: 'whatever' }, {
       stripForbiddenProperties: true,
-    }))
-        .to.eql({ foo: true })
-        .to.have.keys([ 'foo' ])
+    })).toEqual({ foo: true })
 
     expect(strip(validator, { foo: true, baz: 'whatever' }, {
       stripForbiddenProperties: true,
-    }))
-        .to.eql({ foo: true })
-        .to.have.keys([ 'foo' ])
+    })).toEqual({ foo: true })
 
     // strip with unknown/forbidden properties set
     expect(validate(validator, { foo: true, bar: 'whatever', baz: 'forbidden' }, {
       stripAdditionalProperties: true,
       stripForbiddenProperties: true,
-    }))
-        .to.eql({ foo: true })
-        .to.have.keys([ 'foo' ])
+    })).toEqual({ foo: true })
 
     // strip with forbidden properties set
     expect(() => validate(validator, { foo: true, bar: 'whatever', baz: 'forbidden' }, {
       stripAdditionalProperties: true,
-    }))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
+    })).toThrow((assert) => assert
+        .toBeError(ValidationError, /^Found 1 validation error/)
+        .toHaveProperty('errors', expect.toMatchContents([
           { path: [ 'baz' ], message: 'Forbidden property' },
-        ])
+        ])))
 
     // strip with forbidden properties set
     expect(() => validate(validator, { foo: true, bar: 'whatever', baz: 'forbidden' }, {
       stripForbiddenProperties: true,
-    }))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
+    })).toThrow((assert) => assert
+        .toBeError(ValidationError, /^Found 1 validation error/)
+        .toHaveProperty('errors', expect.toMatchContents([
           { path: [ 'bar' ], message: 'Unknown property' },
-        ])
+        ])))
   })
 
   it('should perform a partial validation', () => {
@@ -289,35 +294,39 @@ describe('Object validator', () => {
       ...allowAdditionalProperties(string),
     })
 
-    expect(partial(validation, {})).to.eql({})
-    expect(partial(validation, { required: 'foo' })).to.eql({ required: 'foo' })
-    expect(partial(validation, { optional: false })).to.eql({ optional: false })
-    expect(partial(validation, { defaults: 12345 })).to.eql({ defaults: 12345 })
-    expect(partial(validation, { addition: 'bar' })).to.eql({ addition: 'bar' })
+    expect(partial(validation, {})).toEqual({})
+    expect(partial(validation, { required: 'foo' })).toEqual({ required: 'foo' })
+    expect(partial(validation, { optional: false })).toEqual({ optional: false })
+    expect(partial(validation, { defaults: 12345 })).toEqual({ defaults: 12345 })
+    expect(partial(validation, { addition: 'bar' })).toEqual({ addition: 'bar' })
 
     expect(() => partial(validation, { required: 12345 }))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [ 'required' ], message: 'Value is not a "string"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'required' ], message: 'Value is not a "string"' },
+            ])))
 
     expect(() => partial(validation, { optional: 12345 }))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [ 'optional' ], message: 'Value is not a "boolean"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'optional' ], message: 'Value is not a "boolean"' },
+            ])))
 
     expect(() => partial(validation, { defaults: 'foo' }))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [ 'defaults' ], message: 'Value is not a "number"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'defaults' ], message: 'Value is not a "number"' },
+            ])))
 
     expect(() => partial(validation, { addition: 12345 }))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [ 'addition' ], message: 'Value is not a "string"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'addition' ], message: 'Value is not a "string"' },
+            ])))
   })
 
   it('should extends and allow additional properties', () => {
@@ -325,26 +334,28 @@ describe('Object validator', () => {
     const object2 = object({ ...object1, bar: boolean })
 
     expect(validate(object1, { foo: 'bar', bar: 321, baz: 123 }))
-        .to.eql({ foo: 'bar', bar: 321, baz: 123 })
+        .toEqual({ foo: 'bar', bar: 321, baz: 123 })
     expect(validate(object2, { foo: 'bar', bar: true, baz: 123 }))
-        .to.eql({ foo: 'bar', bar: true, baz: 123 })
+        .toEqual({ foo: 'bar', bar: true, baz: 123 })
 
     expect(() => validate(object1, { foo: 'bar', bar: true, baz: 123 }))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [ 'bar' ], message: 'Value is not a "number"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'bar' ], message: 'Value is not a "number"' },
+            ])))
   })
 
   it('should extends and remove additional properties', () => {
     const object1 = object({ foo: string, ...allowAdditionalProperties(number) })
     const object2 = object({ ...object1, ...allowAdditionalProperties(false) })
 
-    expect(validate(object1, { foo: 'bar', bar: 123 })).to.eql({ foo: 'bar', bar: 123 })
+    expect(validate(object1, { foo: 'bar', bar: 123 })).toEqual({ foo: 'bar', bar: 123 })
     expect(() => validate(object2, { foo: 'bar', bar: 123 }))
-        .to.throw(ValidationError, 'Found 1 validation error')
-        .with.property('errors').to.eql([
-          { path: [ 'bar' ], message: 'Unknown property' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'bar' ], message: 'Unknown property' },
+            ])))
   })
 })

--- a/test/12-objects.test.ts
+++ b/test/12-objects.test.ts
@@ -95,7 +95,7 @@ describe('Object validator', () => {
     expect(() => validate(validator, { version: 2, contents: [] }))
         .to.throw(ValidationError, 'Found 3 validation errors')
         .with.property('errors').to.eql([
-          { path: [ 'version' ], message: 'Value does not match constant "1"' },
+          { path: [ 'version' ], message: 'Value does not match constant "1" (number)' },
           { path: [ 'title' ], message: 'Required property missing' },
           { path: [ 'contents' ], message: 'Array must have a minimum length of 2' },
         ])
@@ -103,7 +103,7 @@ describe('Object validator', () => {
     expect(() => validate(validator, { version: 3, contents: [ {}, 'foo' ] }))
         .to.throw(ValidationError, 'Found 5 validation errors')
         .with.property('errors').to.eql([
-          { path: [ 'version' ], message: 'Value does not match constant "1"' },
+          { path: [ 'version' ], message: 'Value does not match constant "1" (number)' },
           { path: [ 'title' ], message: 'Required property missing' },
           { path: [ 'contents', 0, 'description' ], message: 'Required property missing' },
           { path: [ 'contents', 0, 'value' ], message: 'Required property missing' },
@@ -132,7 +132,7 @@ describe('Object validator', () => {
     expect(() => validate(validator1, { foo: false, bar: 'whatever', baz: true }))
         .to.throw(ValidationError, 'Found 2 validation errors')
         .with.property('errors').to.eql([
-          { path: [ 'foo' ], message: 'Value does not match constant "true"' },
+          { path: [ 'foo' ], message: 'Value does not match constant "true" (boolean)' },
           { path: [ 'baz' ], message: 'Forbidden property' },
         ])
 
@@ -142,7 +142,7 @@ describe('Object validator', () => {
     expect(() => validate(validator2, { foo: false, bar: 'whatever', baz: true }))
         .to.throw(ValidationError, 'Found 2 validation errors')
         .with.property('errors').to.eql([
-          { path: [ 'foo' ], message: 'Value does not match constant "true"' },
+          { path: [ 'foo' ], message: 'Value does not match constant "true" (boolean)' },
           { path: [ 'baz' ], message: 'Forbidden property' },
         ])
 
@@ -152,7 +152,7 @@ describe('Object validator', () => {
     expect(() => validate(validator3, { foo: false, bar: 'whatever', baz: true }))
         .to.throw(ValidationError, 'Found 2 validation errors')
         .with.property('errors').to.eql([
-          { path: [ 'foo' ], message: 'Value does not match constant "true"' },
+          { path: [ 'foo' ], message: 'Value does not match constant "true" (boolean)' },
           { path: [ 'baz' ], message: 'Forbidden property' },
         ])
 

--- a/test/13-optional.test.ts
+++ b/test/13-optional.test.ts
@@ -10,7 +10,7 @@ describe('Object modifiers', () => {
     expect(() => validate(validation, 'wrong'))
         .to.throw(ValidationError, 'Found 1 validation error')
         .with.property('errors').eql([
-          { path: [], message: 'Value does not match constant "foobar"' },
+          { path: [], message: 'Value does not match constant "foobar" (string)' },
         ])
   })
 
@@ -23,8 +23,8 @@ describe('Object modifiers', () => {
     expect(() => validate(validation, [ 'wrong', 12 ]))
         .to.throw(ValidationError, 'Found 2 validation errors')
         .with.property('errors').eql([
-          { path: [ 0 ], message: 'Value does not match constant "foobar"' },
-          { path: [ 1 ], message: 'Value does not match constant "foobar"' },
+          { path: [ 0 ], message: 'Value does not match constant "foobar" (string)' },
+          { path: [ 1 ], message: 'Value does not match constant "foobar" (string)' },
         ])
   })
 
@@ -64,8 +64,8 @@ describe('Object modifiers', () => {
     expect(() => validate(schema, { foo: 'nope', bar: 0, baz: 0 }))
         .to.throw(ValidationError, 'Found 4 validation errors')
         .with.property('errors').eql([
-          { path: [ 'foo' ], message: 'Value does not match constant "hello"' },
-          { path: [ 'foo' ], message: 'Value does not match constant "world"' },
+          { path: [ 'foo' ], message: 'Value does not match constant "hello" (string)' },
+          { path: [ 'foo' ], message: 'Value does not match constant "world" (string)' },
           { path: [ 'bar' ], message: 'Number is less than 5' },
           { path: [ 'baz' ], message: 'Value is not a "string"' },
         ])
@@ -93,8 +93,8 @@ describe('Object modifiers', () => {
         .and.have.property('cause')
         .instanceOf(ValidationError)
         .with.property('errors').eql([
-          { path: [], message: 'Value does not match constant "hello"' },
-          { path: [], message: 'Value does not match constant "world"' },
+          { path: [], message: 'Value does not match constant "hello" (string)' },
+          { path: [], message: 'Value does not match constant "world" (string)' },
         ])
   })
 

--- a/test/13-optional.test.ts
+++ b/test/13-optional.test.ts
@@ -8,7 +8,7 @@ describe('Object modifiers', () => {
     expect(validate(validation, undefined)).to.be.undefined
     expect(validate(validation, 'foobar')).to.equal('foobar')
     expect(() => validate(validation, 'wrong'))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').eql([
           { path: [], message: 'Value does not match constant "foobar" (string)' },
         ])
@@ -21,7 +21,7 @@ describe('Object modifiers', () => {
     expect(validate(validation, [ undefined, 'foobar' ])).to.eql([ undefined, 'foobar' ])
 
     expect(() => validate(validation, [ 'wrong', 12 ]))
-        .to.throw(ValidationError, 'Found 2 validation errors')
+        .to.throw(ValidationError, /^Found 2 validation errors/)
         .with.property('errors').eql([
           { path: [ 0 ], message: 'Value does not match constant "foobar" (string)' },
           { path: [ 1 ], message: 'Value does not match constant "foobar" (string)' },
@@ -41,7 +41,7 @@ describe('Object modifiers', () => {
         .to.eql({ foo: 'hello' })
 
     expect(() => validate(schema1, { foo: 'hello', bar: 40, baz: 60 }))
-        .to.throw(ValidationError, 'Found 2 validation errors')
+        .to.throw(ValidationError, /^Found 2 validation errors/)
         .with.property('errors').eql([
           { path: [ 'bar' ], message: 'Number is less than 50' },
           { path: [ 'baz' ], message: 'Unknown property' },
@@ -62,7 +62,7 @@ describe('Object modifiers', () => {
         .to.eql({ foo: 'world', bar: 15, baz: 'hello' })
 
     expect(() => validate(schema, { foo: 'nope', bar: 0, baz: 0 }))
-        .to.throw(ValidationError, 'Found 4 validation errors')
+        .to.throw(ValidationError, /^Found 4 validation errors/)
         .with.property('errors').eql([
           { path: [ 'foo' ], message: 'Value does not match constant "hello" (string)' },
           { path: [ 'foo' ], message: 'Value does not match constant "world" (string)' },
@@ -80,7 +80,7 @@ describe('Object modifiers', () => {
 
     expect(validate({ test: validator }, {})).to.eql({})
     expect(() => validate({ test: validator }, { test: 123 }))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').eql([
           { path: [ 'test' ], message: 'Value is not a "string"' },
         ])
@@ -114,7 +114,7 @@ describe('Object modifiers', () => {
         .to.eql({ foo: 'hello' })
 
     expect(() => strip(schema1, { foo: 'hello', bar: 40, baz: 60, extra: 'foo' }))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').eql([
           { path: [ 'bar' ], message: 'Number is less than 50' },
         ])

--- a/test/13-optional.test.ts
+++ b/test/13-optional.test.ts
@@ -1,31 +1,31 @@
-import { expect } from 'chai'
-
 import { arrayOf, number, object, oneOf, optional, string, StringValidator, strip, validate, ValidationError } from '../src'
 
 describe('Object modifiers', () => {
   it('should validate a simple optional validation', () => {
     const validation = optional('foobar')
-    expect(validate(validation, undefined)).to.be.undefined
-    expect(validate(validation, 'foobar')).to.equal('foobar')
+    expect(validate(validation, undefined)).toBeUndefined()
+    expect(validate(validation, 'foobar')).toStrictlyEqual('foobar')
     expect(() => validate(validation, 'wrong'))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').eql([
-          { path: [], message: 'Value does not match constant "foobar" (string)' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [], message: 'Value does not match constant "foobar" (string)' },
+            ])))
   })
 
   it('should validate an array with optional elements', () => {
     const validation = arrayOf(optional('foobar'))
-    expect(validate(validation, [ undefined ])).to.eql([ undefined ])
-    expect(validate(validation, [ 'foobar' ])).to.eql([ 'foobar' ])
-    expect(validate(validation, [ undefined, 'foobar' ])).to.eql([ undefined, 'foobar' ])
+    expect(validate(validation, [ undefined ])).toEqual([ undefined ])
+    expect(validate(validation, [ 'foobar' ])).toEqual([ 'foobar' ])
+    expect(validate(validation, [ undefined, 'foobar' ])).toEqual([ undefined, 'foobar' ])
 
     expect(() => validate(validation, [ 'wrong', 12 ]))
-        .to.throw(ValidationError, /^Found 2 validation errors/)
-        .with.property('errors').eql([
-          { path: [ 0 ], message: 'Value does not match constant "foobar" (string)' },
-          { path: [ 1 ], message: 'Value does not match constant "foobar" (string)' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 0 ], message: 'Value does not match constant "foobar" (string)' },
+              { path: [ 1 ], message: 'Value does not match constant "foobar" (string)' },
+            ])))
   })
 
   it('should validate an object with optional properties', () => {
@@ -35,17 +35,18 @@ describe('Object modifiers', () => {
     })
 
     expect(validate(schema1, { foo: 'hello', bar: 50 }))
-        .to.eql({ foo: 'hello', bar: 50 })
+        .toEqual({ foo: 'hello', bar: 50 })
 
     expect(validate(schema1, { foo: 'hello' }))
-        .to.eql({ foo: 'hello' })
+        .toEqual({ foo: 'hello' })
 
     expect(() => validate(schema1, { foo: 'hello', bar: 40, baz: 60 }))
-        .to.throw(ValidationError, /^Found 2 validation errors/)
-        .with.property('errors').eql([
-          { path: [ 'bar' ], message: 'Number is less than 50' },
-          { path: [ 'baz' ], message: 'Unknown property' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'bar' ], message: 'Number is less than 50' },
+              { path: [ 'baz' ], message: 'Unknown property' },
+            ])))
   })
 
   it('should validate an object with optional properties and defaults', () => {
@@ -56,19 +57,20 @@ describe('Object modifiers', () => {
     })
 
     expect(validate(schema, {}))
-        .to.eql({ foo: 'hello', bar: 10, baz: 'world' })
+        .toEqual({ foo: 'hello', bar: 10, baz: 'world' })
 
     expect(validate(schema, { foo: 'world', bar: 15, baz: 'hello' }))
-        .to.eql({ foo: 'world', bar: 15, baz: 'hello' })
+        .toEqual({ foo: 'world', bar: 15, baz: 'hello' })
 
     expect(() => validate(schema, { foo: 'nope', bar: 0, baz: 0 }))
-        .to.throw(ValidationError, /^Found 4 validation errors/)
-        .with.property('errors').eql([
-          { path: [ 'foo' ], message: 'Value does not match constant "hello" (string)' },
-          { path: [ 'foo' ], message: 'Value does not match constant "world" (string)' },
-          { path: [ 'bar' ], message: 'Number is less than 5' },
-          { path: [ 'baz' ], message: 'Value is not a "string"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 4 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'foo' ], message: 'Value does not match constant "hello" (string)' },
+              { path: [ 'foo' ], message: 'Value does not match constant "world" (string)' },
+              { path: [ 'bar' ], message: 'Number is less than 5' },
+              { path: [ 'baz' ], message: 'Value is not a "string"' },
+            ])))
   })
 
   it('should validate an object when a validator is forced as "optional"', () => {
@@ -78,24 +80,26 @@ describe('Object modifiers', () => {
     const validator = new StringValidator()
     validator.optional = true
 
-    expect(validate({ test: validator }, {})).to.eql({})
+    expect(validate({ test: validator }, {})).toEqual({})
     expect(() => validate({ test: validator }, { test: 123 }))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').eql([
-          { path: [ 'test' ], message: 'Value is not a "string"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'test' ], message: 'Value is not a "string"' },
+            ])))
   })
 
   it('should fail when a default value does not match the validation', () => {
     expect(() => object({
       foo: optional(oneOf('hello', 'world'), 'nope' as any),
-    })).to.throw(TypeError, 'Default value does not match validator')
-        .and.have.property('cause')
-        .instanceOf(ValidationError)
-        .with.property('errors').eql([
-          { path: [], message: 'Value does not match constant "hello" (string)' },
-          { path: [], message: 'Value does not match constant "world" (string)' },
-        ])
+    })).toThrow((assert) => assert
+        .toBeError(TypeError, 'Default value does not match validator')
+        .toHaveProperty('cause', expect
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [], message: 'Value does not match constant "hello" (string)' },
+              { path: [], message: 'Value does not match constant "world" (string)' },
+            ]))))
   })
 
   it('should strip an object with optional properties', () => {
@@ -105,18 +109,19 @@ describe('Object modifiers', () => {
     })
 
     expect(strip(schema1, { foo: 'hello', bar: 50, extra: 'foo' }))
-        .to.eql({ foo: 'hello', bar: 50 })
+        .toEqual({ foo: 'hello', bar: 50 })
 
     expect(strip(schema1, { foo: 'hello', bar: null, extra: 'foo' }))
-        .to.eql({ foo: 'hello' })
+        .toEqual({ foo: 'hello' })
 
     expect(strip(schema1, { foo: 'hello', extra: 'foo' }))
-        .to.eql({ foo: 'hello' })
+        .toEqual({ foo: 'hello' })
 
     expect(() => strip(schema1, { foo: 'hello', bar: 40, baz: 60, extra: 'foo' }))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').eql([
-          { path: [ 'bar' ], message: 'Number is less than 50' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'bar' ], message: 'Number is less than 50' },
+            ])))
   })
 })

--- a/test/14-unions.test.ts
+++ b/test/14-unions.test.ts
@@ -1,19 +1,18 @@
-import { expect } from 'chai'
-
 import { allOf, number, oneOf, string, validate, ValidationError } from '../src'
 
 describe('Union validators', () => {
   it('should validate one of the given options', () => {
     const validator = oneOf(string, number)
 
-    expect(validate(validator, 'foo')).to.equal('foo')
-    expect(validate(validator, 12345)).to.equal(12345)
+    expect(validate(validator, 'foo')).toStrictlyEqual('foo')
+    expect(validate(validator, 12345)).toStrictlyEqual(12345)
     expect(() => validate(validator, true))
-        .to.throw(ValidationError, /^Found 2 validation errors/)
-        .with.property('errors').to.eql([
-          { path: [], message: 'Value is not a "string"' },
-          { path: [], message: 'Value is not a "number"' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [], message: 'Value is not a "string"' },
+              { path: [], message: 'Value is not a "number"' },
+            ])))
   })
 
   it('should validate all of the given options', () => {
@@ -22,17 +21,19 @@ describe('Union validators', () => {
 
     const validator = allOf(s1, s2)
 
-    expect(validate(validator, 'foo')).to.equal('foo')
+    expect(validate(validator, 'foo')).toStrictlyEqual('foo')
     expect(() => validate(validator, ''))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([
-          { path: [], message: 'String must have a minimum length of 3' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [], message: 'String must have a minimum length of 3' },
+            ])))
 
     expect(() => validate(validator, 'foobar'))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([
-          { path: [], message: 'String must have a maximum length of 3' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [], message: 'String must have a maximum length of 3' },
+            ])))
   })
 })

--- a/test/14-unions.test.ts
+++ b/test/14-unions.test.ts
@@ -9,7 +9,7 @@ describe('Union validators', () => {
     expect(validate(validator, 'foo')).to.equal('foo')
     expect(validate(validator, 12345)).to.equal(12345)
     expect(() => validate(validator, true))
-        .to.throw(ValidationError, 'Found 2 validation errors')
+        .to.throw(ValidationError, /^Found 2 validation errors/)
         .with.property('errors').to.eql([
           { path: [], message: 'Value is not a "string"' },
           { path: [], message: 'Value is not a "number"' },
@@ -24,13 +24,13 @@ describe('Union validators', () => {
 
     expect(validate(validator, 'foo')).to.equal('foo')
     expect(() => validate(validator, ''))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([
           { path: [], message: 'String must have a minimum length of 3' },
         ])
 
     expect(() => validate(validator, 'foobar'))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([
           { path: [], message: 'String must have a maximum length of 3' },
         ])

--- a/test/15-tuples.test.ts
+++ b/test/15-tuples.test.ts
@@ -5,7 +5,7 @@ import { boolean, number, object, string, tuple, validate, ValidationError } fro
 describe('Tuple validator', () => {
   it('should not validate non-arrays', () => {
     expect(() => validate([], 'string'))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Value is not an "array"',
         } ])
@@ -17,13 +17,13 @@ describe('Tuple validator', () => {
     expect(validate(validator, [])).to.eql([])
 
     expect(() => validate(validator, [ 'foo' ]))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Found 1 element validating empty tuple',
         } ])
 
     expect(() => validate(validator, [ 'foo', 'bar' ]))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Found 2 elements validating empty tuple',
         } ])
@@ -36,25 +36,25 @@ describe('Tuple validator', () => {
         .to.eql([ 'foo', 123, true ])
 
     expect(() => validate(validator, [ 123 ]))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [ 0 ], message: 'Value is not a "string"',
         } ])
 
     expect(() => validate(validator, [ 'foo', 123, true, 'bar' ]))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Found 1 extra element in tuple',
         } ])
 
     expect(() => validate(validator, [ 'foo', 123 ]))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Tuple defines 1 missing validation',
         } ])
 
     expect(() => validate(validator, [ 'foo' ]))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Tuple defines 2 missing validations',
         } ])
@@ -79,13 +79,13 @@ describe('Tuple validator', () => {
         .to.eql([ null, 123 ])
 
     expect(() => validate(validator, [ 'foo', 123 ]))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [ 1 ], message: 'Value does not match constant "null"',
         } ])
 
     expect(() => validate(validator, [ 'foo', null, 123, true ]))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Found 1 extra element in tuple',
         } ])

--- a/test/15-tuples.test.ts
+++ b/test/15-tuples.test.ts
@@ -1,109 +1,116 @@
-import { expect } from 'chai'
-
 import { boolean, number, object, string, tuple, validate, ValidationError } from '../src'
 
 describe('Tuple validator', () => {
   it('should not validate non-arrays', () => {
     expect(() => validate([], 'string'))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Value is not an "array"',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Value is not an "array"',
+            } ])))
   })
 
   it('should validate an empty tuple', () => {
     const validator = tuple([])
 
-    expect(validate(validator, [])).to.eql([])
+    expect(validate(validator, [])).toEqual([])
 
     expect(() => validate(validator, [ 'foo' ]))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Found 1 element validating empty tuple',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Found 1 element validating empty tuple',
+            } ])))
 
     expect(() => validate(validator, [ 'foo', 'bar' ]))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Found 2 elements validating empty tuple',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Found 2 elements validating empty tuple',
+            } ])))
   })
 
   it('should validate a simple tuple', () => {
     const validator = tuple([ string, number, boolean ])
 
     expect(validate(validator, [ 'foo', 123, true ]))
-        .to.eql([ 'foo', 123, true ])
+        .toEqual([ 'foo', 123, true ])
 
     expect(() => validate(validator, [ 123 ]))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [ 0 ], message: 'Value is not a "string"',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [ 0 ], message: 'Value is not a "string"',
+            } ])))
 
     expect(() => validate(validator, [ 'foo', 123, true, 'bar' ]))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Found 1 extra element in tuple',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Found 1 extra element in tuple',
+            } ])))
 
     expect(() => validate(validator, [ 'foo', 123 ]))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Tuple defines 1 missing validation',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Tuple defines 1 missing validation',
+            } ])))
 
     expect(() => validate(validator, [ 'foo' ]))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Tuple defines 2 missing validations',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Tuple defines 2 missing validations',
+            } ])))
   })
 
   it('should validate a tuple with rest parameters', () => {
     const validator = tuple([ ...string, null, ...number ])
 
     expect(validate(validator, [ 'foo', 'bar', null, 123, 456 ]))
-        .to.eql([ 'foo', 'bar', null, 123, 456 ])
+        .toEqual([ 'foo', 'bar', null, 123, 456 ])
     expect(validate(validator, [ 'foo', null, 123 ]))
-        .to.eql([ 'foo', null, 123 ])
+        .toEqual([ 'foo', null, 123 ])
 
     expect(validate(validator, [ 'foo', 'bar', null ]))
-        .to.eql([ 'foo', 'bar', null ])
+        .toEqual([ 'foo', 'bar', null ])
     expect(validate(validator, [ 'foo', null ]))
-        .to.eql([ 'foo', null ])
+        .toEqual([ 'foo', null ])
 
     expect(validate(validator, [ null, 123, 456 ]))
-        .to.eql([ null, 123, 456 ])
+        .toEqual([ null, 123, 456 ])
     expect(validate(validator, [ null, 123 ]))
-        .to.eql([ null, 123 ])
+        .toEqual([ null, 123 ])
 
     expect(() => validate(validator, [ 'foo', 123 ]))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [ 1 ], message: 'Value does not match constant "null"',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [ 1 ], message: 'Value does not match constant "null"',
+            } ])))
 
     expect(() => validate(validator, [ 'foo', null, 123, true ]))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Found 1 extra element in tuple',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Found 1 extra element in tuple',
+            } ])))
   })
 
   it('should validate a tuple with only rest parameters', () => {
     const v1 = tuple([ ...string, ...number ])
     expect(validate(v1, [ 'foo', 'bar', 123, 456 ]))
-        .to.eql([ 'foo', 'bar', 123, 456 ])
+        .toEqual([ 'foo', 'bar', 123, 456 ])
 
     expect(validate(v1, [ 'foo', 'bar' ]))
-        .to.eql([ 'foo', 'bar' ])
+        .toEqual([ 'foo', 'bar' ])
 
     expect(validate(v1, [ 123, 456 ]))
-        .to.eql([ 123, 456 ])
+        .toEqual([ 123, 456 ])
 
     expect(validate(v1, []))
-        .to.eql([])
+        .toEqual([])
   })
 
   it('should validate a tuple with an object rest parameter', () => {
@@ -111,12 +118,12 @@ describe('Tuple validator', () => {
     const v1 = tuple([ number, ...o1, boolean ])
 
     expect(validate(v1, [ 123, true ]))
-        .to.eql([ 123, true ])
+        .toEqual([ 123, true ])
 
     expect(validate(v1, [ 123, { foo: 'bar' }, true ]))
-        .to.eql([ 123, { foo: 'bar' }, true ])
+        .toEqual([ 123, { foo: 'bar' }, true ])
 
     expect(validate(v1, [ 123, { foo: 'bar' }, { foo: 'baz' }, true ]))
-        .to.eql([ 123, { foo: 'bar' }, { foo: 'baz' }, true ])
+        .toEqual([ 123, { foo: 'bar' }, { foo: 'baz' }, true ])
   })
 })

--- a/test/16-dates.test.ts
+++ b/test/16-dates.test.ts
@@ -1,93 +1,99 @@
-import { expect } from 'chai'
-
 import { date, validate, ValidationError } from '../src'
 
 describe('Date validator', () => {
   it('should validate a simple date', () => {
-    expect(validate(date, 0).getTime()).to.eql(0)
-    expect(validate(date, '1970-01-01T00:00:00.000Z').getTime()).to.eql(0)
-    expect(validate(date, 'Thu, 01 Jan 1970 00:00:00 GMT').getTime()).to.eql(0)
+    expect(validate(date, 0).getTime()).toEqual(0)
+    expect(validate(date, '1970-01-01T00:00:00.000Z').getTime()).toEqual(0)
+    expect(validate(date, 'Thu, 01 Jan 1970 00:00:00 GMT').getTime()).toEqual(0)
   })
 
   it('should validate a Date instance', () => {
     const now = new Date()
-    expect(validate(date, now).getTime()).to.eql(now.getTime())
+    expect(validate(date, now).getTime()).toEqual(now.getTime())
   })
 
   it('should validate an ISO date', () => {
     const validator = date({ format: 'iso' })
 
-    expect(validate(validator, '1970-01-01T00:00:00.000Z').getTime()).to.eql(0)
+    expect(validate(validator, '1970-01-01T00:00:00.000Z').getTime()).toEqual(0)
 
     expect(() => validate(validator, 'Thu, 01 Jan 1970 00:00:00 GMT'))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Invalid format for ISO Date',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Invalid format for ISO Date',
+            } ])))
   })
 
   it('should validate a timestamp', () => {
     const validator = date({ format: 'timestamp' })
 
-    expect(validate(validator, 0).getTime()).to.eql(0)
+    expect(validate(validator, 0).getTime()).toEqual(0)
 
     expect(() => validate(validator, 'Thu, 01 Jan 1970 00:00:00 GMT'))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Timestamp is not a "number"',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Timestamp is not a "number"',
+            } ])))
   })
 
   it('should validate a date within a range', () => {
     const v1 = date({ from: new Date(2000), until: new Date(3000) })
 
-    expect(validate(v1, 2000).getTime()).to.eql(2000)
-    expect(validate(v1, 3000).getTime()).to.eql(3000)
+    expect(validate(v1, 2000).getTime()).toEqual(2000)
+    expect(validate(v1, 3000).getTime()).toEqual(3000)
 
     expect(() => validate(v1, 1999))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Date is before 1970-01-01T00:00:02.000Z',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Date is before 1970-01-01T00:00:02.000Z',
+            } ])))
 
     expect(() => validate(v1, 3001))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Date is after 1970-01-01T00:00:03.000Z',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Date is after 1970-01-01T00:00:03.000Z',
+            } ])))
 
 
     const v2 = date({ from: new Date(2000), until: new Date(2000) })
 
-    expect(validate(v2, 2000).getTime()).to.eql(2000)
+    expect(validate(v2, 2000).getTime()).toEqual(2000)
 
     expect(() => validate(v2, 1999))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Date is before 1970-01-01T00:00:02.000Z',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Date is before 1970-01-01T00:00:02.000Z',
+            } ])))
 
     expect(() => validate(v2, 2001))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Date is after 1970-01-01T00:00:02.000Z',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Date is after 1970-01-01T00:00:02.000Z',
+            } ])))
 
     expect(() => date({ from: new Date(100), until: new Date(99) }))
-        .to.throw(TypeError, 'Constraint "until" (1970-01-01T00:00:00.099Z) must not be before "from" (1970-01-01T00:00:00.100Z)')
+        .toThrowError(TypeError, 'Constraint "until" (1970-01-01T00:00:00.099Z) must not be before "from" (1970-01-01T00:00:00.100Z)')
   })
 
   it('should consider edge cases', () => {
     expect(() => validate(date, Symbol()))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Value could not be converted to a "Date"',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Value could not be converted to a "Date"',
+            } ])))
 
     expect(() => validate(date, Number.POSITIVE_INFINITY))
-        .to.throw(ValidationError, /^Found 1 validation error/)
-        .with.property('errors').to.eql([ {
-          path: [], message: 'Invalid date',
-        } ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 1 validation error/)
+            .toHaveProperty('errors', expect.toMatchContents([ {
+              path: [], message: 'Invalid date',
+            } ])))
   })
 })

--- a/test/16-dates.test.ts
+++ b/test/16-dates.test.ts
@@ -20,7 +20,7 @@ describe('Date validator', () => {
     expect(validate(validator, '1970-01-01T00:00:00.000Z').getTime()).to.eql(0)
 
     expect(() => validate(validator, 'Thu, 01 Jan 1970 00:00:00 GMT'))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Invalid format for ISO Date',
         } ])
@@ -32,7 +32,7 @@ describe('Date validator', () => {
     expect(validate(validator, 0).getTime()).to.eql(0)
 
     expect(() => validate(validator, 'Thu, 01 Jan 1970 00:00:00 GMT'))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Timestamp is not a "number"',
         } ])
@@ -45,13 +45,13 @@ describe('Date validator', () => {
     expect(validate(v1, 3000).getTime()).to.eql(3000)
 
     expect(() => validate(v1, 1999))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Date is before 1970-01-01T00:00:02.000Z',
         } ])
 
     expect(() => validate(v1, 3001))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Date is after 1970-01-01T00:00:03.000Z',
         } ])
@@ -62,13 +62,13 @@ describe('Date validator', () => {
     expect(validate(v2, 2000).getTime()).to.eql(2000)
 
     expect(() => validate(v2, 1999))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Date is before 1970-01-01T00:00:02.000Z',
         } ])
 
     expect(() => validate(v2, 2001))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Date is after 1970-01-01T00:00:02.000Z',
         } ])
@@ -79,13 +79,13 @@ describe('Date validator', () => {
 
   it('should consider edge cases', () => {
     expect(() => validate(date, Symbol()))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Value could not be converted to a "Date"',
         } ])
 
     expect(() => validate(date, Number.POSITIVE_INFINITY))
-        .to.throw(ValidationError, 'Found 1 validation error')
+        .to.throw(ValidationError, /^Found 1 validation error/)
         .with.property('errors').to.eql([ {
           path: [], message: 'Invalid date',
         } ])

--- a/test/20-conversion.test.ts
+++ b/test/20-conversion.test.ts
@@ -1,5 +1,3 @@
-import { expect } from 'chai'
-
 import { arrayOf, date, object, tuple, validate } from '../src'
 
 describe('Type conversion', () => {
@@ -7,35 +5,35 @@ describe('Type conversion', () => {
     const src = [ 0 ]
     const tgt = validate(arrayOf(date), src)
 
-    expect(src).not.to.equal(tgt)
-    expect(src).to.eql([ 0 ])
+    expect(src).not.toStrictlyEqual(tgt)
+    expect(src).toEqual([ 0 ])
 
-    expect(tgt).to.be.an('array').with.length(1)
-    expect(tgt[0]).to.be.instanceOf(Date)
-    expect(tgt[0].getTime()).to.equal(0)
+    expect(tgt).toBeA('array').toHaveLength(1)
+    expect(tgt[0]).toBeInstanceOf(Date)
+    expect(tgt[0].getTime()).toStrictlyEqual(0)
   })
 
   it('should convert types in tuples', () => {
     const src = [ 0 ]
     const tgt = validate(tuple([ date ]), src)
 
-    expect(src).not.to.equal(tgt)
-    expect(src).to.eql([ 0 ])
+    expect(src).not.toStrictlyEqual(tgt)
+    expect(src).toEqual([ 0 ])
 
-    expect(tgt).to.be.an('array').with.length(1)
-    expect(tgt[0]).to.be.instanceOf(Date)
-    expect(tgt[0].getTime()).to.equal(0)
+    expect(tgt).toBeA('array').toHaveLength(1)
+    expect(tgt[0]).toBeInstanceOf(Date)
+    expect(tgt[0].getTime()).toStrictlyEqual(0)
   })
 
   it('should convert types in objects', () => {
     const src = { foo: 0 }
     const tgt = validate(object({ foo: date }), src)
 
-    expect(src).not.to.equal(tgt)
-    expect(src).to.eql({ foo: 0 })
+    expect(src).not.toStrictlyEqual(tgt)
+    expect(src).toEqual({ foo: 0 })
 
-    expect(tgt).to.be.an('object')
-    expect(tgt.foo).to.be.instanceOf(Date)
-    expect(tgt.foo.getTime()).to.equal(0)
+    expect(tgt).toBeA('object')
+    expect(tgt.foo).toBeInstanceOf(Date)
+    expect(tgt.foo.getTime()).toStrictlyEqual(0)
   })
 })

--- a/test/50-extra-url.test.ts
+++ b/test/50-extra-url.test.ts
@@ -26,7 +26,7 @@ describe('URL validator', () => {
     expect(validator.validate('http://www/a/b/c#foo').href).to.equal('http://www/a/b/c#foo')
 
     expect(() => validator.validate('ftp://funet/fi'))
-        .to.throw(ValidationError, 'Found 3 validation errors')
+        .to.throw(ValidationError, /^Found 3 validation errors/)
         .with.property('errors').to.eql([
           { path: [ 'protocol' ], message: 'String does not match required pattern /^https?:$/' },
           { path: [ 'hostname' ], message: 'Value does not match constant "www" (string)' },
@@ -44,7 +44,7 @@ describe('URL validator', () => {
 
     expect(validator.validate('http://www/?foo=bar&baz=xyz').href).to.eql('http://www/?foo=bar&baz=xyz')
     expect(() => validator.validate('http://www/?baz=abc').href)
-        .to.throw(ValidationError, 'Found 2 validation errors')
+        .to.throw(ValidationError, /^Found 2 validation errors/)
         .with.property('errors').to.eql([
           { path: [ 'searchParams', 'foo' ], message: 'Required property missing' },
           { path: [ 'searchParams', 'baz' ], message: 'Value does not match constant "xyz" (string)' },

--- a/test/50-extra-url.test.ts
+++ b/test/50-extra-url.test.ts
@@ -1,18 +1,16 @@
-import { expect } from 'chai'
-
 import { constant, optional, string, validate, ValidationError } from '../src'
 import { url } from '../src/extra/url'
 
 describe('URL validator', () => {
   it('should validate a simple URL', () => {
-    expect(validate(url, 'http://www/').href).to.equal('http://www/')
-    expect(validate(url, 'foo:bar/baz').href).to.equal('foo:bar/baz')
-    expect(validate(url, new URL('http://www/')).href).to.equal('http://www/')
+    expect(validate(url, 'http://www/').href).toStrictlyEqual('http://www/')
+    expect(validate(url, 'foo:bar/baz').href).toStrictlyEqual('foo:bar/baz')
+    expect(validate(url, new URL('http://www/')).href).toStrictlyEqual('http://www/')
   })
 
   it('should not validate a wrong URL', () => {
     expect(() => validate(url, '/foo/bar'))
-        .to.throw(ValidationError, 'Value could not be converted to a "URL"')
+        .toThrowError(ValidationError, /Value could not be converted to a "URL"/)
   })
 
   it('should validate an URL with some basic constraints', () => {
@@ -23,15 +21,16 @@ describe('URL validator', () => {
       hash: undefined, // have the key but no value
     })
 
-    expect(validator.validate('http://www/a/b/c#foo').href).to.equal('http://www/a/b/c#foo')
+    expect(validator.validate('http://www/a/b/c#foo').href).toStrictlyEqual('http://www/a/b/c#foo')
 
     expect(() => validator.validate('ftp://funet/fi'))
-        .to.throw(ValidationError, /^Found 3 validation errors/)
-        .with.property('errors').to.eql([
-          { path: [ 'protocol' ], message: 'String does not match required pattern /^https?:$/' },
-          { path: [ 'hostname' ], message: 'Value does not match constant "www" (string)' },
-          { path: [ 'pathname' ], message: 'Value does not match constant "/a/b/c" (string)' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 3 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'protocol' ], message: 'String does not match required pattern /^https?:$/' },
+              { path: [ 'hostname' ], message: 'Value does not match constant "www" (string)' },
+              { path: [ 'pathname' ], message: 'Value does not match constant "/a/b/c" (string)' },
+            ])))
   })
 
   it('should validate an URL with some search parameters constraints', () => {
@@ -42,12 +41,13 @@ describe('URL validator', () => {
       },
     })
 
-    expect(validator.validate('http://www/?foo=bar&baz=xyz').href).to.eql('http://www/?foo=bar&baz=xyz')
+    expect(validator.validate('http://www/?foo=bar&baz=xyz').href).toEqual('http://www/?foo=bar&baz=xyz')
     expect(() => validator.validate('http://www/?baz=abc').href)
-        .to.throw(ValidationError, /^Found 2 validation errors/)
-        .with.property('errors').to.eql([
-          { path: [ 'searchParams', 'foo' ], message: 'Required property missing' },
-          { path: [ 'searchParams', 'baz' ], message: 'Value does not match constant "xyz" (string)' },
-        ])
+        .toThrow((assert) => assert
+            .toBeError(ValidationError, /^Found 2 validation errors/)
+            .toHaveProperty('errors', expect.toMatchContents([
+              { path: [ 'searchParams', 'foo' ], message: 'Required property missing' },
+              { path: [ 'searchParams', 'baz' ], message: 'Value does not match constant "xyz" (string)' },
+            ])))
   })
 })

--- a/test/50-extra-url.test.ts
+++ b/test/50-extra-url.test.ts
@@ -29,8 +29,8 @@ describe('URL validator', () => {
         .to.throw(ValidationError, 'Found 3 validation errors')
         .with.property('errors').to.eql([
           { path: [ 'protocol' ], message: 'String does not match required pattern /^https?:$/' },
-          { path: [ 'hostname' ], message: 'Value does not match constant "www"' },
-          { path: [ 'pathname' ], message: 'Value does not match constant "/a/b/c"' },
+          { path: [ 'hostname' ], message: 'Value does not match constant "www" (string)' },
+          { path: [ 'pathname' ], message: 'Value does not match constant "/a/b/c" (string)' },
         ])
   })
 
@@ -47,7 +47,7 @@ describe('URL validator', () => {
         .to.throw(ValidationError, 'Found 2 validation errors')
         .with.property('errors').to.eql([
           { path: [ 'searchParams', 'foo' ], message: 'Required property missing' },
-          { path: [ 'searchParams', 'baz' ], message: 'Value does not match constant "xyz"' },
+          { path: [ 'searchParams', 'baz' ], message: 'Value does not match constant "xyz" (string)' },
         ])
   })
 })

--- a/test/99-dts.test.ts
+++ b/test/99-dts.test.ts
@@ -1,5 +1,3 @@
-import { expect } from 'chai'
-
 import {
   allOf,
   allowAdditionalProperties,
@@ -38,200 +36,200 @@ describe('DTS Generation', () => {
     it('should generate the validated type for some basic types', () => {
       expect(generateTypes({
         test: any,
-      })).to.equal('export type test = any;')
+      })).toStrictlyEqual('export type test = any;')
 
       expect(generateTypes({
         test: array,
-      })).to.equal('export type test = any[];')
+      })).toStrictlyEqual('export type test = any[];')
 
       expect(generateTypes({
         test: number,
-      })).to.equal('export type test = number;')
+      })).toStrictlyEqual('export type test = number;')
 
       expect(generateTypes({
         test: object,
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = { [key in string]: any; };')
+          .toStrictlyEqual('export type test = { [key in string]: any; };')
 
       expect(generateTypes({
         test: string,
-      })).to.equal('export type test = string;')
+      })).toStrictlyEqual('export type test = string;')
 
       expect(generateTypes({
         test: boolean,
-      })).to.equal('export type test = boolean;')
+      })).toStrictlyEqual('export type test = boolean;')
 
       expect(generateTypes({
         test: bigint,
-      })).to.equal('export type test = bigint;')
+      })).toStrictlyEqual('export type test = bigint;')
 
       expect(generateTypes({
         test: date,
-      })).to.equal('export type test = Date;')
+      })).toStrictlyEqual('export type test = Date;')
 
       expect(generateTypes({
         test: never,
-      })).to.equal('export type test = undefined;')
+      })).toStrictlyEqual('export type test = undefined;')
     })
 
     it('should generate the validated type for some basic validators', () => {
       expect(generateTypes({
         test: new AnyValidator(),
-      })).to.equal('export type test = any;')
+      })).toStrictlyEqual('export type test = any;')
 
       expect(generateTypes({
         test: new AnyArrayValidator(),
-      })).to.equal('export type test = any[];')
+      })).toStrictlyEqual('export type test = any[];')
 
       expect(generateTypes({
         test: new AnyBigIntValidator(),
-      })).to.equal('export type test = bigint;')
+      })).toStrictlyEqual('export type test = bigint;')
 
       expect(generateTypes({
         test: new AnyNumberValidator(),
-      })).to.equal('export type test = number;')
+      })).toStrictlyEqual('export type test = number;')
 
       expect(generateTypes({
         test: new AnyObjectValidator(),
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = { [key in string]: any; };')
+          .toStrictlyEqual('export type test = { [key in string]: any; };')
 
       expect(generateTypes({
         test: new AnyStringValidator(),
-      })).to.equal('export type test = string;')
+      })).toStrictlyEqual('export type test = string;')
 
       expect(generateTypes({
         test: new BooleanValidator(),
-      })).to.equal('export type test = boolean;')
+      })).toStrictlyEqual('export type test = boolean;')
 
       expect(generateTypes({
         test: new BigIntValidator(),
-      })).to.equal('export type test = bigint;')
+      })).toStrictlyEqual('export type test = bigint;')
 
       expect(generateTypes({
         test: new DateValidator(),
-      })).to.equal('export type test = Date;')
+      })).toStrictlyEqual('export type test = Date;')
 
       expect(generateTypes({
         test: new NeverValidator(),
-      })).to.equal('export type test = undefined;')
+      })).toStrictlyEqual('export type test = undefined;')
     })
 
     it('should generate the validated type for arrays', () => {
       expect(generateTypes({
         test: array,
-      })).to.equal('export type test = any[];')
+      })).toStrictlyEqual('export type test = any[];')
 
       expect(generateTypes({
         test: arrayOf(string),
-      })).to.equal('export type test = string[];')
+      })).toStrictlyEqual('export type test = string[];')
     })
 
     it('should generate the validated type for constants', () => {
       expect(generateTypes({
         test: 'a string',
-      })).to.equal('export type test = "a string";')
+      })).toStrictlyEqual('export type test = "a string";')
 
       expect(generateTypes({
         test: 12345,
-      })).to.equal('export type test = 12345;')
+      })).toStrictlyEqual('export type test = 12345;')
 
       expect(generateTypes({
         test: 1234n,
-      })).to.equal('export type test = 1234n;')
+      })).toStrictlyEqual('export type test = 1234n;')
 
       expect(generateTypes({
         test: false,
-      })).to.equal('export type test = false;')
+      })).toStrictlyEqual('export type test = false;')
 
       expect(generateTypes({
         test: true,
-      })).to.equal('export type test = true;')
+      })).toStrictlyEqual('export type test = true;')
 
       expect(generateTypes({
         test: null,
-      })).to.equal('export type test = null;')
+      })).toStrictlyEqual('export type test = null;')
 
       expect(() => generateTypes({
         test: constant(<any> { toString: () => 'foo' }),
-      })).to.throw(TypeError, 'Invalid constant "foo"')
+      })).toThrowError(TypeError, 'Invalid constant "foo"')
     })
 
     it('should generate the validated type for (branded) bigints', () => {
       expect(generateTypes({
         test: bigint({}),
-      })).to.equal('export type test = bigint;')
+      })).toStrictlyEqual('export type test = bigint;')
 
       expect(generateTypes({
         test: bigint({ brand: 'foo' }),
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = bigint & { __brand_foo: never; };')
+          .toStrictlyEqual('export type test = bigint & { __brand_foo: never; };')
     })
 
     it('should generate the validated type for (branded) numbers', () => {
       expect(generateTypes({
         test: number({}),
-      })).to.equal('export type test = number;')
+      })).toStrictlyEqual('export type test = number;')
 
       expect(generateTypes({
         test: number({ brand: 'foo' }),
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = number & { __brand_foo: never; };')
+          .toStrictlyEqual('export type test = number & { __brand_foo: never; };')
     })
 
     it('should generate the validated type for (branded) strings', () => {
       expect(generateTypes({
         test: string({}),
-      })).to.equal('export type test = string;')
+      })).toStrictlyEqual('export type test = string;')
 
       expect(generateTypes({
         test: string({ brand: 'foo' }),
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = string & { __brand_foo: never; };')
+          .toStrictlyEqual('export type test = string & { __brand_foo: never; };')
     })
 
     it('should generate the validated type for tuples', () => {
       expect(generateTypes({
         test: [],
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = [ ];')
+          .toStrictlyEqual('export type test = [ ];')
 
       expect(generateTypes({
         test: [ number, string, boolean ],
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = [ number, string, boolean ];')
+          .toStrictlyEqual('export type test = [ number, string, boolean ];')
 
       expect(generateTypes({
         test: [ 12345, 'foo', null ],
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = [ 12345, "foo", null ];')
+          .toStrictlyEqual('export type test = [ 12345, "foo", null ];')
 
       expect(generateTypes({
         test: [ number, ...string, boolean ],
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = [ number, ...string[], boolean ];')
+          .toStrictlyEqual('export type test = [ number, ...string[], boolean ];')
 
       // combine types in unions when multiple rest parameters exist..
 
       expect(generateTypes({
         test: [ ...number, string, ...boolean ],
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = [ ...(number | string | boolean)[] ];')
+          .toStrictlyEqual('export type test = [ ...(number | string | boolean)[] ];')
 
       expect(generateTypes({
         test: [ 'foo', ...number, string, ...boolean, 'bar' ],
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = [ "foo", ...(number | string | boolean)[], "bar" ];')
+          .toStrictlyEqual('export type test = [ "foo", ...(number | string | boolean)[], "bar" ];')
     })
 
     it('should generate the validated type for unions', () => {
       expect(generateTypes({
         test: allOf(string, number, boolean),
-      })).to.equal('export type test = string & number & boolean;')
+      })).toStrictlyEqual('export type test = string & number & boolean;')
 
       expect(generateTypes({
         test: oneOf(string, number, boolean),
-      })).to.equal('export type test = string | number | boolean;')
+      })).toStrictlyEqual('export type test = string | number | boolean;')
     })
 
     it('should generate the validated type for optionals', () => {
@@ -239,7 +237,7 @@ describe('DTS Generation', () => {
         hasDefault: optional(string, 'foobar'),
         noDefault: optional(number),
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type hasDefault = string; export type noDefault = number | undefined;')
+          .toStrictlyEqual('export type hasDefault = string; export type noDefault = number | undefined;')
 
       expect(generateTypes({
         test: {
@@ -247,7 +245,7 @@ describe('DTS Generation', () => {
           noDefault: optional(oneOf('foo', 'bar')),
         },
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = { hasDefault: "foo" | "bar"; noDefault?: "foo" | "bar" | undefined; };')
+          .toStrictlyEqual('export type test = { hasDefault: "foo" | "bar"; noDefault?: "foo" | "bar" | undefined; };')
     })
 
     it('should generate the validated type for optionals in input mode', () => {
@@ -255,7 +253,7 @@ describe('DTS Generation', () => {
         hasDefault: optional(string, 'foobar'),
         noDefault: optional(number),
       }, true).replace(/\s+/gm, ' '))
-          .to.equal('export type hasDefault = string | undefined; export type noDefault = number | undefined;')
+          .toStrictlyEqual('export type hasDefault = string | undefined; export type noDefault = number | undefined;')
 
       expect(generateTypes({
         test: {
@@ -263,19 +261,19 @@ describe('DTS Generation', () => {
           noDefault: optional(oneOf('foo', 'bar')),
         },
       }, true).replace(/\s+/gm, ' '))
-          .to.equal('export type test = { hasDefault?: "foo" | "bar" | undefined; noDefault?: "foo" | "bar" | undefined; };')
+          .toStrictlyEqual('export type test = { hasDefault?: "foo" | "bar" | undefined; noDefault?: "foo" | "bar" | undefined; };')
     })
 
     it('should generate the validated type for objects', () => {
       expect(generateTypes({
         test: object,
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = { [key in string]: any; };')
+          .toStrictlyEqual('export type test = { [key in string]: any; };')
 
       expect(generateTypes({
         test: object({}),
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = {};')
+          .toStrictlyEqual('export type test = {};')
 
       expect(generateTypes({
         test: object({
@@ -285,7 +283,7 @@ describe('DTS Generation', () => {
           x: null,
         }),
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = { s: string; n: number; b: boolean; x: null; };')
+          .toStrictlyEqual('export type test = { s: string; n: number; b: boolean; x: null; };')
 
       expect(generateTypes({
         test: object({
@@ -293,7 +291,7 @@ describe('DTS Generation', () => {
           x: never,
         }),
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = { n?: number | undefined; x?: undefined; };')
+          .toStrictlyEqual('export type test = { n?: number | undefined; x?: undefined; };')
 
       expect(generateTypes({
         test: object({
@@ -301,7 +299,7 @@ describe('DTS Generation', () => {
           ...allowAdditionalProperties,
         }),
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = { s: string; } & { [key in string]: any; };')
+          .toStrictlyEqual('export type test = { s: string; } & { [key in string]: any; };')
 
       expect(generateTypes({
         test: object({
@@ -309,7 +307,7 @@ describe('DTS Generation', () => {
           ...allowAdditionalProperties(),
         }),
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = { s: string; } & { [key in string]: any; };')
+          .toStrictlyEqual('export type test = { s: string; } & { [key in string]: any; };')
 
       expect(generateTypes({
         test: object({
@@ -317,14 +315,14 @@ describe('DTS Generation', () => {
           ...allowAdditionalProperties(number),
         }),
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = { s: string; } & { [key in string]: number; };')
+          .toStrictlyEqual('export type test = { s: string; } & { [key in string]: number; };')
 
       expect(generateTypes({
         test: object({
           ...allowAdditionalProperties(number),
         }),
       }).replace(/\s+/gm, ' '))
-          .to.equal('export type test = { [key in string]: number; };')
+          .toStrictlyEqual('export type test = { [key in string]: number; };')
     })
   })
 
@@ -332,67 +330,67 @@ describe('DTS Generation', () => {
     it('should generate the input type for booleans', () => {
       expect(generateTypes({
         test: boolean,
-      }, true)).to.equal('export type test = boolean;')
+      }, true)).toStrictlyEqual('export type test = boolean;')
 
       expect(generateTypes({
         test: boolean({ fromString: true }),
-      }, true)).to.equal('export type test = boolean | "true" | "false";')
+      }, true)).toStrictlyEqual('export type test = boolean | "true" | "false";')
     })
 
     it('should generate the input type for (branded) bigints', () => {
       expect(generateTypes({
         test: bigint({}),
-      }, true)).to.equal('export type test = bigint | number;')
+      }, true)).toStrictlyEqual('export type test = bigint | number;')
 
       expect(generateTypes({
         test: bigint({ fromString: true }),
-      }, true)).to.equal('export type test = bigint | number | string;')
+      }, true)).toStrictlyEqual('export type test = bigint | number | string;')
 
       expect(generateTypes({
         test: bigint({ fromNumber: false }),
-      }, true)).to.equal('export type test = bigint;')
+      }, true)).toStrictlyEqual('export type test = bigint;')
 
       expect(generateTypes({
         test: bigint({ brand: 'foo' }),
-      }, true)).to.equal('export type test = bigint | number;')
+      }, true)).toStrictlyEqual('export type test = bigint | number;')
     })
 
     it('should generate the input type for (branded) numbers', () => {
       expect(generateTypes({
         test: number({}),
-      }, true)).to.equal('export type test = number;')
+      }, true)).toStrictlyEqual('export type test = number;')
 
       expect(generateTypes({
         test: number({ fromString: true }),
-      }, true)).to.equal('export type test = number | string;')
+      }, true)).toStrictlyEqual('export type test = number | string;')
 
       expect(generateTypes({
         test: number({ brand: 'foo' }),
-      }, true)).to.equal('export type test = number;')
+      }, true)).toStrictlyEqual('export type test = number;')
     })
 
     it('should generate the input type for (branded) strings', () => {
       expect(generateTypes({
         test: string({}),
-      }, true)).to.equal('export type test = string;')
+      }, true)).toStrictlyEqual('export type test = string;')
 
       expect(generateTypes({
         test: string({ brand: 'foo' }),
-      }, true)).to.equal('export type test = string;')
+      }, true)).toStrictlyEqual('export type test = string;')
     })
 
     it('should generate the input type for dates', () => {
       expect(generateTypes({
         test: date,
-      }, true)).to.equal('export type test = Date | number | string;')
+      }, true)).toStrictlyEqual('export type test = Date | number | string;')
 
       expect(generateTypes({
         test: date({ format: 'iso' }),
-      }, true)).to.equal('export type test = string;')
+      }, true)).toStrictlyEqual('export type test = string;')
 
       expect(generateTypes({
         test: date({ format: 'timestamp' }),
-      }, true)).to.equal('export type test = number;')
+      }, true)).toStrictlyEqual('export type test = number;')
     })
   })
 
@@ -401,34 +399,34 @@ describe('DTS Generation', () => {
       expect(generateTypes({
         test: ean13,
       }).replace(/\s+/gm, ' ').trim())
-          .to.equal('export type test = string & { __ean_13: never; };')
+          .toStrictlyEqual('export type test = string & { __ean_13: never; };')
 
       expect(generateTypes({
         test: new EAN13Validator(),
       }).replace(/\s+/gm, ' ').trim())
-          .to.equal('export type test = string & { __ean_13: never; };')
+          .toStrictlyEqual('export type test = string & { __ean_13: never; };')
     })
 
     it('url', () => {
       expect(generateTypes({
         test: url,
-      })).to.equal('export type test = URL;')
+      })).toStrictlyEqual('export type test = URL;')
 
       expect(generateTypes({
         test: new URLValidator(),
-      })).to.equal('export type test = URL;')
+      })).toStrictlyEqual('export type test = URL;')
     })
 
     it('uuid', () => {
       expect(generateTypes({
         test: uuid,
       }).replace(/\s+/gm, ' ').trim())
-          .to.equal('export type test = string & { __uuid: never; };')
+          .toStrictlyEqual('export type test = string & { __uuid: never; };')
 
       expect(generateTypes({
         test: new UUIDValidator(),
       }).replace(/\s+/gm, ' ').trim())
-          .to.equal('export type test = string & { __uuid: never; };')
+          .toStrictlyEqual('export type test = string & { __uuid: never; };')
     })
   })
 
@@ -436,31 +434,31 @@ describe('DTS Generation', () => {
     it('ean 13', () => {
       expect(generateTypes({
         test: ean13,
-      }, true)).to.equal('export type test = number | string;')
+      }, true)).toStrictlyEqual('export type test = number | string;')
 
       expect(generateTypes({
         test: new EAN13Validator(),
-      }, true)).to.equal('export type test = number | string;')
+      }, true)).toStrictlyEqual('export type test = number | string;')
     })
 
     it('url', () => {
       expect(generateTypes({
         test: url,
-      }, true)).to.equal('export type test = URL | string;')
+      }, true)).toStrictlyEqual('export type test = URL | string;')
 
       expect(generateTypes({
         test: new URLValidator(),
-      }, true)).to.equal('export type test = URL | string;')
+      }, true)).toStrictlyEqual('export type test = URL | string;')
     })
 
     it('uuid', () => {
       expect(generateTypes({
         test: uuid,
-      }, true)).to.equal('export type test = string;')
+      }, true)).toStrictlyEqual('export type test = string;')
 
       expect(generateTypes({
         test: new UUIDValidator(),
-      }, true)).to.equal('export type test = string;')
+      }, true)).toStrictlyEqual('export type test = string;')
     })
   })
 
@@ -488,7 +486,7 @@ describe('DTS Generation', () => {
       // run our little test...
       expect(generateTypes({ ean, product, test })
           .replace(/\s+/gm, ' ').trim())
-          .to.equal(expected)
+          .toStrictlyEqual(expected)
     })
 
     it('should reference exported validators in input types', () => {
@@ -514,7 +512,7 @@ describe('DTS Generation', () => {
       // run our little test...
       expect(generateTypes({ ean, product, test }, true)
           .replace(/\s+/gm, ' ').trim())
-          .to.equal(expected)
+          .toStrictlyEqual(expected)
     })
 
     it('should generate a full type declaration', () => {
@@ -538,7 +536,7 @@ describe('DTS Generation', () => {
 
       log.info(result)
 
-      expect(result.split('\n').map((s) => s.trim())).to.eql(`
+      expect(result.split('\n').map((s) => s.trim())).toEqual(`
         /* ----- ean ---------------------------------------------------------------- */
         /** Validated type for {@link ean} */
         export type Ean = string & {
@@ -599,7 +597,7 @@ describe('DTS Generation', () => {
 
       log.info(result)
 
-      expect(result.split('\n').map((s) => s.trim())).to.eql(`
+      expect(result.split('\n').map((s) => s.trim())).toEqual(`
         /* ----- nullValidator ------------------------------------------------------ */
         /** Validated type for {@link nullValidator} */
         export type Null = null;
@@ -648,7 +646,7 @@ describe('DTS Generation', () => {
 
       log.info(result)
 
-      expect(result.split('\n').map((s) => s.trim())).to.eql(`
+      expect(result.split('\n').map((s) => s.trim())).toEqual(`
         /* ----- myObjectValidator -------------------------------------------------- */
         /** Validated type for {@link myObjectValidator} */
         export type MyObject = {
@@ -675,7 +673,7 @@ describe('DTS Generation', () => {
 
       log.info(result)
 
-      expect(result.split('\n').map((s) => s.trim())).to.eql(`
+      expect(result.split('\n').map((s) => s.trim())).toEqual(`
         /* ----- myObjectValidator -------------------------------------------------- */
         /** Validated type for {@link myObjectValidator} */
         export type MyObject = {
@@ -699,7 +697,7 @@ describe('DTS Generation', () => {
 
       log.info(result)
 
-      expect(result.split('\n').map((s) => s.trim())).to.eql(`
+      expect(result.split('\n').map((s) => s.trim())).toEqual(`
         /* ----- myObjectValidator -------------------------------------------------- */
         /** Validated type for {@link myObjectValidator} */
         export type MyObject = {
@@ -721,7 +719,7 @@ describe('DTS Generation', () => {
 
       log.info(result)
 
-      expect(result.split('\n').map((s) => s.trim())).to.eql(`
+      expect(result.split('\n').map((s) => s.trim())).toEqual(`
         /* ----- myTuple ------------------------------------------------------------ */
         /** Validated type for {@link myTuple} */
         export type MyTuple = [
@@ -737,7 +735,7 @@ describe('DTS Generation', () => {
 
     it('should fail generating a full type declaration including straight tuples', () => {
       expect(() => generateDeclarations({ noTuples: [ string ] }))
-          .to.throw(TypeError, 'Unable to generate variable declaration for TupleValidator')
+          .toThrowError(TypeError, 'Unable to generate variable declaration for TupleValidator')
     })
   })
 })

--- a/test/99-dts.test.ts
+++ b/test/99-dts.test.ts
@@ -5,12 +5,15 @@ import {
   allowAdditionalProperties,
   any,
   AnyArrayValidator,
+  AnyBigIntValidator,
   AnyNumberValidator,
   AnyObjectValidator,
   AnyStringValidator,
   AnyValidator,
   array,
   arrayOf,
+  bigint,
+  BigIntValidator,
   boolean,
   BooleanValidator,
   constant,
@@ -59,6 +62,10 @@ describe('DTS Generation', () => {
       })).to.equal('export type test = boolean;')
 
       expect(generateTypes({
+        test: bigint,
+      })).to.equal('export type test = bigint;')
+
+      expect(generateTypes({
         test: date,
       })).to.equal('export type test = Date;')
 
@@ -77,6 +84,10 @@ describe('DTS Generation', () => {
       })).to.equal('export type test = any[];')
 
       expect(generateTypes({
+        test: new AnyBigIntValidator(),
+      })).to.equal('export type test = bigint;')
+
+      expect(generateTypes({
         test: new AnyNumberValidator(),
       })).to.equal('export type test = number;')
 
@@ -92,6 +103,10 @@ describe('DTS Generation', () => {
       expect(generateTypes({
         test: new BooleanValidator(),
       })).to.equal('export type test = boolean;')
+
+      expect(generateTypes({
+        test: new BigIntValidator(),
+      })).to.equal('export type test = bigint;')
 
       expect(generateTypes({
         test: new DateValidator(),
@@ -122,6 +137,10 @@ describe('DTS Generation', () => {
       })).to.equal('export type test = 12345;')
 
       expect(generateTypes({
+        test: 1234n,
+      })).to.equal('export type test = 1234n;')
+
+      expect(generateTypes({
         test: false,
       })).to.equal('export type test = false;')
 
@@ -136,6 +155,17 @@ describe('DTS Generation', () => {
       expect(() => generateTypes({
         test: constant(<any> { toString: () => 'foo' }),
       })).to.throw(TypeError, 'Invalid constant "foo"')
+    })
+
+    it('should generate the validated type for (branded) bigints', () => {
+      expect(generateTypes({
+        test: bigint({}),
+      })).to.equal('export type test = bigint;')
+
+      expect(generateTypes({
+        test: bigint({ brand: 'foo' }),
+      }).replace(/\s+/gm, ' '))
+          .to.equal('export type test = bigint & { __brand_foo: never; };')
     })
 
     it('should generate the validated type for (branded) numbers', () => {
@@ -307,6 +337,24 @@ describe('DTS Generation', () => {
       expect(generateTypes({
         test: boolean({ fromString: true }),
       }, true)).to.equal('export type test = boolean | "true" | "false";')
+    })
+
+    it('should generate the input type for (branded) bigints', () => {
+      expect(generateTypes({
+        test: bigint({}),
+      }, true)).to.equal('export type test = bigint | number;')
+
+      expect(generateTypes({
+        test: bigint({ fromString: true }),
+      }, true)).to.equal('export type test = bigint | number | string;')
+
+      expect(generateTypes({
+        test: bigint({ fromNumber: false }),
+      }, true)).to.equal('export type test = bigint;')
+
+      expect(generateTypes({
+        test: bigint({ brand: 'foo' }),
+      }, true)).to.equal('export type test = bigint | number;')
     })
 
     it('should generate the input type for (branded) numbers', () => {


### PR DESCRIPTION
* Support for `bigint` as a primitive, constant, ...
* Support for _partial_ validations
* Switch from Chai to Expect5
* Little cleanups here and there...
